### PR TITLE
Harden the #13-#22 endpoints: job lock deadlock, force=True remove, dest writes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  test_importsession:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Install dependencies
+        run: pip install beets flask
+
+      - name: Run test_importsession.py
+        run: python test_importsession.py

--- a/beetsgui.html
+++ b/beetsgui.html
@@ -1312,7 +1312,7 @@ function removeFormat(fmt){
     .then(data=>{
       if(!data.items.length){el.innerHTML='<div class="lib-empty">No '+fmt+' tracks in the library.</div>';return;}
       if(!confirm('Remove '+data.items.length+' '+fmt+' track'+(data.items.length===1?'':'s')+' from the database? Files stay on disk.'))return;
-      fetch('/library/remove',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({query,delete_files:false})})
+      fetch('/library/remove',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({query,expect:data.items.length,delete_files:false})})
         .then(r=>r.json())
         .then(d=>{el.innerHTML=d.ok
           ?'<div class="alert alert-green">Removed '+data.items.length+' track'+(data.items.length===1?'':'s')+' from the database.</div>'
@@ -1347,14 +1347,27 @@ function previewRemove(which){
 function doRemove(which,deleteFiles){
   const query=removeQuery(which),el=removeResultsEl(which);
   if(!query){alert('Enter a query first.');return;}
-  const msg=(deleteFiles?'Permanently delete files matching "':'Remove from database (files stay on disk) matching "')+query+'"? Preview first to check what matches.';
-  if(!confirm(msg))return;
-  fetch('/library/remove',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({query,delete_files:deleteFiles})})
+  // Preview before confirming, not just "you should preview": the count in the
+  // prompt is the real match count, and the server requires it back as `expect`
+  // (it removes with force=true, so this preview is the only confirmation).
+  el.innerHTML='<div class="lib-empty">Checking what matches…</div>';
+  fetch('/library/remove/preview',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({query})})
     .then(r=>r.json())
     .then(data=>{
-      el.innerHTML=data.ok?'<div class="alert alert-green">Done.</div>':'<div class="lib-empty">'+escapeHtml(data.error||'Failed.')+'</div>';
+      if(!data.ok){el.innerHTML='<div class="lib-empty">'+escapeHtml(data.error||'Preview failed.')+'</div>';return;}
+      const n=data.items.length;
+      if(!n){el.innerHTML='<div class="lib-empty">No matching tracks — nothing to remove.</div>';return;}
+      const msg=(deleteFiles?'Permanently delete files for ':'Remove from database (files stay on disk): ')+
+        n+' track'+(n===1?'':'s')+' matching "'+query+'"?';
+      if(!confirm(msg)){el.innerHTML='<div class="lib-empty">Cancelled.</div>';return;}
+      fetch('/library/remove',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({query,expect:n,delete_files:deleteFiles})})
+        .then(r=>r.json())
+        .then(d=>{
+          el.innerHTML=d.ok?'<div class="alert alert-green">Removed '+d.removed+' track'+(d.removed===1?'':'s')+'.</div>':'<div class="lib-empty">'+escapeHtml(d.error||'Failed.')+'</div>';
+        })
+        .catch(()=>alert('Could not reach the server.'));
     })
-    .catch(()=>alert('Could not reach the server.'));
+    .catch(()=>{el.innerHTML='<div class="lib-empty">Could not reach the server.</div>';});
 }
 function exportM3u(dest,resultsId){
   const el=document.getElementById(resultsId);

--- a/importsession.py
+++ b/importsession.py
@@ -267,7 +267,19 @@ class ImportJob(jobs.Job):
                 if not 0 <= index < p['n_candidates']:
                     return f"candidate must be 0..{p['n_candidates'] - 1}"
                 reply = {'choice': 'apply', 'candidate': index}
-            p['answer'].put(reply)
+            # A decision is single-use, and clearing it here rather than in
+            # ask()'s finally is what makes that true: a duplicate answer (a
+            # double-clicked button, a retried request) used to be accepted
+            # and then block in put() on the maxsize=1 queue *while holding
+            # this lock*, which wedges ask()'s own cleanup, pending() and
+            # abort() — permanently, since nothing else drains that queue.
+            # Rejected answers above must leave the decision open, so this
+            # only happens once the reply is known to be valid.
+            self._pending = None
+            try:
+                p['answer'].put_nowait(reply)
+            except queue.Full:
+                return 'decision already answered'
             return None
 
     def abort(self):

--- a/libops.py
+++ b/libops.py
@@ -18,6 +18,7 @@ from platform import python_version
 
 import beets
 from beets import library, plugins
+from beets.ui import UserError
 from beets.ui.commands.remove import remove_items as _remove_items
 from beets.ui.commands.update import update_items as _update_items
 from beets.ui.commands.utils import do_query
@@ -35,8 +36,29 @@ from importsession import get_library
 _console_lock = threading.Lock()
 
 
+# Fields that aren't metadata. `path` is the sharpest: setting it redirects
+# try_sync's tag write to whatever file the new path names, and then store()
+# persists it, so the real file is orphaned and an unrelated media file gets
+# this item's tags. `id`/`album_id` collide database rows. beets' own `beet
+# modify` allows all three, but there the user typed the field name; here it
+# arrives in a JSON body behind a free-text input.
+PROTECTED_FIELDS = {'path', 'id', 'album_id'}
+
+
 def split_query(query):
-    return shlex.split(query) if query else []
+    """Split a beets query string. Raises UserError on unbalanced quotes,
+    which the endpoints turn into a 400 rather than a 500."""
+    if not query:
+        return []
+    try:
+        return shlex.split(query)
+    except ValueError as e:
+        raise UserError(f'could not parse query: {e}')
+
+
+def _check_field(field):
+    if field in PROTECTED_FIELDS:
+        raise UserError(f'{field} is not an editable metadata field')
 
 
 def _capture(fn, *args, **kwargs):
@@ -50,6 +72,7 @@ def _capture(fn, *args, **kwargs):
 
 def preview_modify(field, value, query):
     """Items the query matches, with their current and would-be new value."""
+    _check_field(field)
     lib = get_library()
     items = list(lib.items(split_query(query)))
     template = functemplate.template(value)
@@ -65,6 +88,7 @@ def preview_modify(field, value, query):
 
 def apply_modify(field, value, query):
     """Apply the change previewed by preview_modify(). Returns count changed."""
+    _check_field(field)
     lib = get_library()
     items = list(lib.items(split_query(query)))
     template = functemplate.template(value)

--- a/server.py
+++ b/server.py
@@ -57,7 +57,66 @@ SAFARI_APP_NAME = 'BeetsGUI'
 # ── Flask app ────────────────────────────────────────────────────────────────
 app = Flask(__name__)
 
+
+@app.before_request
+def _reject_foreign_host():
+    """Block DNS-rebinding: only serve requests addressed to this loopback
+    origin. Without this, a page on any hostname that resolves to
+    127.0.0.1 is same-origin from the browser's perspective and can hit
+    every endpoint here, CORS preflight or not."""
+    if request.host not in (f'localhost:{PORT}', f'127.0.0.1:{PORT}'):
+        return jsonify({'ok': False, 'error': 'bad host'}), 403
+
+
+@app.errorhandler(UserError)
+def _bad_query(e):
+    """A malformed beets query is the caller's mistake, not a server fault.
+    Endpoints that catch UserError themselves still do; this catches the ones
+    that don't, so an unbalanced quote is a 400 instead of a 500."""
+    return jsonify({'ok': False, 'error': str(e)}), 400
+
+
 # ── Helper functions ──────────────────────────────────────────────────────────
+def _busy_response():
+    """409 if a background job is running, else None.
+
+    beets' `config` and `Library` are process-global (see jobs.py), and Flask
+    is threaded, so a mutating request served while a job's worker thread is
+    mid-run touches the same singletons. The job registry only serialises
+    jobs against each other — this extends that to the mutating endpoints.
+    Read-only endpoints are deliberately not gated.
+    """
+    job = jobs.current()
+    if not job:
+        return None
+    return jsonify({'ok': False,
+                    'error': f'a {job.kind} job is running — wait for it to finish'}), 409
+
+
+# Writing a list to a caller-supplied path: refuse anything that isn't
+# obviously one of this app's own outputs. Same-user localhost is still the
+# trust model, but "empty match set silently truncates ~/.zshrc" is not a
+# capability this app needs to have.
+LIST_SUFFIXES = {'.txt', '.m3u', '.m3u8'}
+
+
+def _write_list(dest, lines):
+    """Write `lines` to `dest`. Returns (path, None) or (None, error)."""
+    path = Path(os.path.expanduser(dest))
+    if path.suffix.lower() not in LIST_SUFFIXES:
+        return None, f'dest must end in one of {sorted(LIST_SUFFIXES)}'
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Filenames can hold bytes that aren't valid UTF-8; they arrive here
+        # surrogate-escaped, so write them back the same way rather than
+        # raising UnicodeEncodeError halfway through.
+        path.write_text('\n'.join(lines) + ('\n' if lines else ''),
+                        errors='surrogateescape')
+    except OSError as e:
+        return None, str(e)
+    return path, None
+
+
 def find_beet() -> str:
     """Find the beet executable. Checks Homebrew paths first."""
     candidates = [
@@ -139,9 +198,13 @@ def open_app_when_ready():
 @app.route('/library')
 def library():
     """Read albums directly from the beets library.db (read-only)."""
-    q      = request.args.get('q', '').strip()
-    limit  = min(int(request.args.get('limit', 200)), 1000)
-    offset = int(request.args.get('offset', 0))
+    q = request.args.get('q', '').strip()
+    try:
+        limit  = min(int(request.args.get('limit', 200)), 1000)
+        offset = max(int(request.args.get('offset', 0)), 0)
+    except ValueError:
+        return jsonify({'ok': False,
+                        'error': 'limit and offset must be integers'}), 400
     db_path = get_library_db_path()
 
     if not Path(db_path).exists():
@@ -189,6 +252,8 @@ def list_duplicates():
 def delete_duplicate():
     """Remove one album (by id) from the library. Body: {"id": 1,
     "delete_files": true}. Always a single explicit target."""
+    if busy := _busy_response():
+        return busy
     data = request.get_json(silent=True) or {}
     album_id = data.get('id')
     if not isinstance(album_id, int):
@@ -227,6 +292,8 @@ def library_modify_preview():
 
 @app.route('/library/modify', methods=['POST'])
 def library_modify():
+    if busy := _busy_response():
+        return busy
     data = request.get_json(silent=True) or {}
     field, value = data.get('field'), data.get('value')
     if not field or value is None:
@@ -237,10 +304,14 @@ def library_modify():
 
 @app.route('/library/update', methods=['POST'])
 def library_update():
-    """Body: {"query": "...", "pretend": true}."""
+    """Body: {"query": "...", "pretend": true}. `pretend` defaults to true:
+    this rewrites library rows, so an omitted flag must not mean "do it"."""
+    if busy := _busy_response():
+        return busy
     data = request.get_json(silent=True) or {}
     try:
-        output = libops.update(data.get('query', ''), bool(data.get('pretend')))
+        output = libops.update(data.get('query', ''),
+                               bool(data.get('pretend', True)))
     except UserError as e:
         return jsonify({'ok': False, 'error': str(e)}), 400
     return jsonify({'ok': True, 'output': output})
@@ -248,10 +319,14 @@ def library_update():
 
 @app.route('/library/write', methods=['POST'])
 def library_write():
-    """Body: {"query": "...", "pretend": true}."""
+    """Body: {"query": "...", "pretend": true}. `pretend` defaults to true:
+    this writes tags into files, so an omitted flag must not mean "do it"."""
+    if busy := _busy_response():
+        return busy
     data = request.get_json(silent=True) or {}
     try:
-        output = libops.write(data.get('query', ''), bool(data.get('pretend')))
+        output = libops.write(data.get('query', ''),
+                              bool(data.get('pretend', True)))
     except UserError as e:
         return jsonify({'ok': False, 'error': str(e)}), 400
     return jsonify({'ok': True, 'output': output})
@@ -266,26 +341,51 @@ def library_missing():
 def library_remove_preview():
     """Body: {"query": "..."}."""
     data = request.get_json(silent=True) or {}
+    query = data.get('query', '')
+    # Parse first, so a malformed query is a 400 (via the UserError handler)
+    # rather than being swallowed below and reported as "nothing matches" —
+    # this preview is what gates the destructive remove, so the two cases
+    # must not look identical.
+    libops.split_query(query)
     try:
-        items = libops.preview_remove(data.get('query', ''))
+        items = libops.preview_remove(query)
     except UserError:
-        items = []
+        items = []          # beets raises this when nothing matches
     return jsonify({'ok': True, 'items': items})
 
 
 @app.route('/library/remove', methods=['POST'])
 def library_remove():
-    """Body: {"query": "...", "delete_files": false}. "Remove short files"
-    is the same call with query=length:..N, built client-side."""
+    """Body: {"query": "...", "expect": 12, "delete_files": false}.
+    "Remove short files" is the same call with query=length:..N, built
+    client-side.
+
+    `expect` is the item count the caller previewed and is required, because
+    libops.remove() passes force=True to beets — the preview *is* the
+    confirmation, so this endpoint has to verify one actually happened and
+    still describes the same set. Mismatch means the library changed under
+    the caller, and the answer is to preview again rather than to guess.
+    """
+    if busy := _busy_response():
+        return busy
     data = request.get_json(silent=True) or {}
     query = data.get('query', '')
+    expect = data.get('expect')
     if not query.strip():
         return jsonify({'ok': False, 'error': 'query is required'}), 400
+    if not isinstance(expect, int) or isinstance(expect, bool):
+        return jsonify({'ok': False,
+                        'error': 'expect (the previewed item count) is required'}), 400
     try:
+        actual = len(libops.preview_remove(query))
+        if actual != expect:
+            return jsonify({'ok': False, 'error': (
+                f'the library changed since the preview — {actual} items match '
+                f'now, not {expect}. Preview again.')}), 409
         libops.remove(query, bool(data.get('delete_files')))
     except UserError as e:
         return jsonify({'ok': False, 'error': str(e)}), 400
-    return jsonify({'ok': True})
+    return jsonify({'ok': True, 'removed': actual})
 
 
 def _known_track_keys(con):
@@ -369,6 +469,20 @@ def _scan_files(dir_path, exclude, exts=None):
         yield f
 
 
+def _walk_roots(dir_path):
+    """Immediate subdirectories of dir_path, sorted, symlinks excluded.
+
+    `rglob` doesn't follow symlinks inside a tree, but it does walk whatever
+    root it is handed — and `is_dir()` follows symlinks, so a symlinked
+    subfolder pointing at `/` used to become a walk root and take the whole
+    filesystem with it (confirmed live in issue #30: the request never
+    returned). Walking the `dir` the caller explicitly named is intended;
+    silently following a symlink found inside it is not.
+    """
+    return sorted(p for p in Path(dir_path).iterdir()
+                  if p.is_dir() and not p.is_symlink())
+
+
 def _parse_exts(raw):
     """'wav,aiff' -> {'.wav', '.aiff'}, or None (meaning AUDIO_EXTENSIONS)
     if empty."""
@@ -414,12 +528,9 @@ def scan_save_list():
     exclude = _parse_exclude(data.get('exclude', ''))
     dest = (data.get('dest') or '~/Desktop/music_list.txt').strip()
     files = sorted(str(f) for f in _scan_files(dir_path, exclude))
-    path = Path(os.path.expanduser(dest))
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text('\n'.join(files) + ('\n' if files else ''))
-    except OSError as e:
-        return jsonify({'ok': False, 'error': str(e)}), 500
+    path, error = _write_list(dest, files)
+    if error:
+        return jsonify({'ok': False, 'error': error}), 400
     return jsonify({'ok': True, 'count': len(files), 'path': str(path)})
 
 
@@ -431,7 +542,7 @@ def scan_sizes():
     if not dir_path or not os.path.isdir(dir_path):
         return jsonify({'ok': False, 'error': 'no such directory'}), 400
     folders = []
-    for sub in sorted(p for p in Path(dir_path).iterdir() if p.is_dir()):
+    for sub in _walk_roots(dir_path):
         size = sum(f.stat().st_size for f in sub.rglob('*') if f.is_file())
         folders.append({'path': str(sub), 'size_bytes': size})
     return jsonify({'ok': True, 'folders': folders})
@@ -479,13 +590,9 @@ def export_m3u():
         return jsonify({'ok': False, 'error': 'dest is required'}), 400
     lib = importsession.get_library()
     items = list(lib.items(libops.split_query(data.get('query', ''))))
-    path = Path(os.path.expanduser(dest))
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        lines = [displayable_path(i.path) for i in items]
-        path.write_text('\n'.join(lines) + ('\n' if lines else ''))
-    except OSError as e:
-        return jsonify({'ok': False, 'error': str(e)}), 500
+    path, error = _write_list(dest, [displayable_path(i.path) for i in items])
+    if error:
+        return jsonify({'ok': False, 'error': error}), 400
     return jsonify({'ok': True, 'count': len(items), 'path': str(path)})
 
 
@@ -504,7 +611,7 @@ def export_playlists():
     dest_dir.mkdir(parents=True, exist_ok=True)
 
     written = []
-    for sub in sorted(p for p in Path(src).iterdir() if p.is_dir()):
+    for sub in _walk_roots(src):
         files = sorted(
             f for f in sub.rglob('*')
             if f.is_file() and f.suffix.lower() in AUDIO_EXTENSIONS
@@ -512,7 +619,8 @@ def export_playlists():
         if not files:
             continue
         out = dest_dir / f'{sub.name}.m3u'
-        out.write_text('\n'.join(str(f) for f in files) + '\n')
+        out.write_text('\n'.join(str(f) for f in files) + '\n',
+                       errors='surrogateescape')
         written.append(out.name)
 
     return jsonify({'ok': True, 'playlists': written, 'dest': str(dest_dir)})

--- a/test_importsession.py
+++ b/test_importsession.py
@@ -262,6 +262,20 @@ def main():
                 decide(event, choice='skip')
         assert albums_in(beetsdir) == before, 'skip should not add an album'
 
+        # 3b. Answering the same decision twice: the duplicate is rejected and
+        #     the server stays responsive. A duplicate answer used to be
+        #     accepted and then block in put() on the maxsize=1 reply queue
+        #     while holding the job lock, which wedged the importer's own
+        #     cleanup, /jobs/current and abort for the life of the process.
+        for event in run(src / 'three'):
+            if event['type'] == 'decision':
+                decide(event, choice='skip')
+                code, reply = decide(event, expect=409, choice='skip')
+                assert 'decision' in reply['error'], reply
+                with urllib.request.urlopen(f'{BASE}/jobs/current', timeout=5) as r:
+                    assert json.load(r)['ok'], 'jobs/current must not hang'
+        assert albums_in(beetsdir) == before, 'skip should not add an album'
+
         # 4. Abort while a decision is blocked: the job finishes, nothing added.
         stream = run(src / 'three')
         for event in stream:


### PR DESCRIPTION
Adversarial pass over the endpoints that shipped in #13-#22, which had never had one. Closes #29, and includes the fix for the DoS confirmed in #30.

Full findings report with reasoning: https://github.com/fastermadman/beetsGUI/issues/29#issuecomment-5185780439

Every item was **confirmed before being fixed** — by a local probe or against a scratch library with a scratch `BEETSDIR`, never the real one. All test artifacts torn down.

## The headline

The documented justification for `force=True` was false. `libops.remove` bypasses beets' own confirmation on the stated grounds that *"the web UI's preview step already is the confirmation"* — but `doRemove()` never previewed. It put the words "Preview first to check what matches" inside a `confirm()` string and posted straight to `/library/remove`. The most irreversible path in the app had no enumeration of what it was about to delete.

## What's fixed

| # | Finding | Severity |
|---|---|---|
| N1 | `ImportJob.answer()` accepted a decision_id repeatedly and blocked in `put()` holding the job lock — wedges `pending()`, `abort()` and the importer's own cleanup, so the single-flight registry refuses **every future job** until restart | high, stability |
| N2 | `/library/remove`'s preview was advisory; now `expect` makes it load-bearing | high |
| N3 | Mutating endpoints ran concurrently with background jobs against beets' process-global singletons (#27 R4) | medium |
| N4 | `field` reached `path`/`id`/`album_id` — `path` redirects the tag write to an arbitrary file and orphans the real one | medium |
| N5 | Arbitrary file truncation via `dest`; an **empty** match set was enough | medium |
| N6 | Four endpoints returned 500 on a malformed query; `?limit=abc` too | low |
| N7 | `pretend` defaulted to "do it" on `/library/update` and `/library/write` | low |
| — | `/scan/sizes` and `/export/playlists` took symlinked subdirs as walk roots (#30) | fixed here |

## Evidence, in short

N1, deterministic probe against a constructed `ImportJob`:
```
A1 -> returned: None   queue size now 1
A2 -> started          (never returns — blocked in put() holding _lock)
pending() while A2 blocked: BLOCKED — lock held by A2
abort()  while A2 blocked: BLOCKED — lock held by A2
```

N2, against a scratch library with 3 items:
```
expect: 1  (actually 3)  -> 409 "3 items match now, not 1. Preview again."  nothing removed
expect: 3                -> 200 {"removed": 3}
```

N4:
```
path -> accepted. _type=PathType  parsed=b'/Users/valdefar/.ssh/authorized_keys'
after setting field="path": item.path = b'/Users/valdefar/.ssh/authorized_keys'
```

N5:
```
before: IMPORTANT ORIGINAL CONTENT
POST /scan/save-list {"dir":"<empty dir>","dest":"/tmp/probe-victim.conf"} -> {"count":0,"ok":true}
after:  (0 bytes)
```

#30 repro: went from never returning to **0.012s**, still reporting the real subdirectory.

## Verification

- Full `test_importsession.py` passes on the final tree, including a new case 3b that answers the same decision twice and asserts the duplicate is refused and `/jobs/current` still responds.
- Every fix additionally exercised live against a scratch server on an alt port.

## Deliberately not in this PR

Flagged in the report and tracked separately — each needs a design decision rather than a guard, and none is a security boundary: unbounded `job.events` queue, `sync` jobs ignoring abort (can wedge the registry with no way out), multiple SSE consumers splitting events, and `/scan/sizes?dir=/` as an uncapped walk.

## Review notes

- `/library/remove` is an **API break**: `expect` is now required. Only `beetsgui.html` calls it, and both call sites are updated.
- `/library/update` and `/library/write` change default behaviour when `pretend` is omitted (now a dry run). The UI always sends it explicitly, so no UI change.
- `libops.PROTECTED_FIELDS` is a blocklist. A dropdown of actually-editable fields in the UI would make it unnecessary — noted, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
