### PR TITLE
Metadata section: field dropdown, two-step update/write, and two bugs it exposed

### DIFF
--- a/beetsgui.html
+++ b/beetsgui.html
@@ -385,7 +385,7 @@
       <div class="section">
         <div class="section-title">Metadata</div>
         <div class="field-row">
-          <div class="field"><label>Field</label><input type="text" id="mod-field" placeholder="artist"></div>
+          <div class="field"><label>Field</label><select id="mod-field"><option value="">Loading fields…</option></select></div>
           <div class="field"><label>New value</label><input type="text" id="mod-value" placeholder="Burial"></div>
           <div class="field"><label>Query</label><input type="text" id="mod-query" placeholder="album:Untrue"></div>
         </div>
@@ -396,12 +396,8 @@
         <hr class="divider">
         <div class="field"><label>Query (all fields if empty)</label><input type="text" id="maint-query" placeholder="album:Untrue"></div>
         <div class="btn-row">
-          <button class="btn" onclick="runUpdate(true)">Preview update</button>
-          <button class="btn btn-primary" onclick="runUpdate(false)">Apply update</button>
-        </div>
-        <div class="btn-row">
-          <button class="btn" onclick="runWrite(true)">Preview write</button>
-          <button class="btn btn-primary" onclick="runWrite(false)">Apply write</button>
+          <button class="btn btn-primary" onclick="runUpdate()">Check for changes on disk</button>
+          <button class="btn btn-primary" onclick="runWrite()">Check tags to write</button>
         </div>
         <div class="btn-row">
           <button class="btn" onclick="startSync('mbsync')">mbsync <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Network call per track/album — can be slow on a real library.</span></span></button>
@@ -455,7 +451,7 @@
               </select>
             </div>
             <div class="field" style="align-self:flex-end;">
-              <label class="check-item"><input type="checkbox" id="beet-conv-pretend" checked><span>Preview only (--pretend)</span></label>
+              <label class="check-item"><input type="checkbox" id="beet-conv-pretend" checked><span>Preview only — don't write files yet</span></label>
             </div>
           </div>
           <div class="field"><label>Destination (blank = convert.dest from config)</label><input type="text" id="beet-conv-dest" placeholder="~/Music/Converted"></div>
@@ -1240,22 +1236,33 @@ function applyModify(){
     })
     .catch(()=>alert('Could not reach the server.'));
 }
-function runMaint(kind,pretend){
+// Both of these used to be two independent buttons — a "Preview" and an
+// "Apply" you could click without ever previewing. Now Apply only exists
+// once a preview has shown what it would do, the same shape as
+// previewModify()/applyModify() and as /library/remove's expect check.
+const MAINT_LABELS={update:{verb:'Update the library',noun:'change'},
+                    write:{verb:'Write these tags to files',noun:'file'}};
+function runMaint(kind,apply){
   const query=document.getElementById('maint-query').value.trim();
   const el=document.getElementById('maint-results');
   el.innerHTML='<div class="lib-empty">Working…</div>';
-  fetch('/library/'+kind,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({query,pretend})})
+  fetch('/library/'+kind,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({query,pretend:!apply})})
     .then(r=>r.json())
     .then(data=>{
       if(!data.ok){el.innerHTML='<div class="lib-empty">'+escapeHtml(data.error||'Failed.')+'</div>';return;}
-      el.innerHTML=data.output.length
-        ?'<pre class="pre-out">'+escapeHtml(data.output.join('\n'))+'</pre>'
-        :'<div class="lib-empty">No changes'+(pretend?' — nothing would happen':'')+'.</div>';
+      if(!data.output.length){
+        el.innerHTML='<div class="lib-empty">Nothing to do — nothing would change.</div>';return;
+      }
+      const out='<pre class="pre-out">'+escapeHtml(data.output.join('\n'))+'</pre>';
+      if(apply){el.innerHTML='<div class="alert alert-green">Done.</div>'+out;return;}
+      const l=MAINT_LABELS[kind];
+      el.innerHTML=out+'<div class="btn-row"><button class="btn btn-primary btn-sm" '+
+        'onclick="runMaint(\''+kind+'\',true)">'+l.verb+'</button></div>';
     })
     .catch(()=>{el.innerHTML='<div class="lib-empty">Could not reach the server.</div>';});
 }
-function runUpdate(pretend){runMaint('update',pretend);}
-function runWrite(pretend){runMaint('write',pretend);}
+function runUpdate(){runMaint('update',false);}
+function runWrite(){runMaint('write',false);}
 function showMissing(){
   const el=document.getElementById('maint-results');
   el.innerHTML='<div class="lib-empty">Loading…</div>';
@@ -1293,6 +1300,32 @@ function showFields(){
     el.innerHTML='<div class="lib-count">Item fields</div><div class="path-preview">'+escapeHtml(data.item_fields.join(', '))+'</div>'+
       '<div class="lib-count" style="margin-top:0.5rem;">Album fields</div><div class="path-preview">'+escapeHtml(data.album_fields.join(', '))+'</div>';
   }).catch(()=>{el.innerHTML='<div class="lib-empty">Could not reach the server.</div>';});
+}
+// The fields people actually retag, first in the list. The rest of beets'
+// item fields still follow, so nothing is hidden — but "which of these 80
+// do I want" isn't a question the common case should have to answer.
+// Plural forms are deliberate: beets 2.x renamed genre/composer to the list
+// fields genres/composers, and the singular names silently become flexible
+// attributes that never reach the files.
+const COMMON_FIELDS=['artist','albumartist','album','title','genres','year',
+                     'track','disc','composers','label','comments'];
+// Not metadata: the server rejects these (libops.PROTECTED_FIELDS) because
+// `path` redirects the tag write and `id`/`album_id` collide DB rows.
+const NON_FIELDS=['path','id','album_id'];
+function loadModFields(){
+  const sel=document.getElementById('mod-field');
+  fetch('/info/fields').then(r=>r.json()).then(data=>{
+    if(!data.ok)throw new Error(data.error);
+    const all=data.item_fields.filter(f=>!NON_FIELDS.includes(f));
+    const common=COMMON_FIELDS.filter(f=>all.includes(f));
+    const rest=all.filter(f=>!common.includes(f));
+    const opt=f=>'<option value="'+escapeHtml(f)+'">'+escapeHtml(f)+'</option>';
+    sel.innerHTML=common.map(opt).join('')+
+      (rest.length?'<optgroup label="other fields">'+rest.map(opt).join('')+'</optgroup>':'');
+  }).catch(()=>{
+    // Fall back to the common list so the section still works offline.
+    sel.innerHTML=COMMON_FIELDS.map(f=>'<option value="'+f+'">'+f+'</option>').join('');
+  });
 }
 function showVersion(resultsId){
   const el=document.getElementById(resultsId||'info-results');
@@ -1621,7 +1654,7 @@ function toggleBp4Method(){
   if(localStorage.getItem('cmdBoxOpen')==='1')box.open=true;
   box.addEventListener('toggle',()=>localStorage.setItem('cmdBoxOpen',box.open?'1':'0'));
 })();
-updatePathPreview();checkCurrentImport();
+updatePathPreview();checkCurrentImport();loadModFields();
 </script>
 </body>
 </html>

--- a/beetsgui.html
+++ b/beetsgui.html
@@ -442,22 +442,17 @@
       command: ffmpeg -i $source -c:a alac -map_metadata 0 $dest
       extension: m4a</pre>
           </div>
-          <div class="field-row">
-            <div class="field">
-              <label>Source format</label>
-              <select id="beet-conv-fmt">
-                <option value="AIFF">AIFF</option>
-                <option value="WAV">WAV</option>
-                <option value="FLAC">FLAC</option>
-              </select>
-            </div>
-            <div class="field" style="align-self:flex-end;">
-              <label class="check-item"><input type="checkbox" id="beet-conv-pretend" checked><span>Preview only — don't write files yet</span></label>
-            </div>
+          <div class="field">
+            <label>Source format</label>
+            <select id="beet-conv-fmt">
+              <option value="AIFF">AIFF</option>
+              <option value="WAV">WAV</option>
+              <option value="FLAC">FLAC</option>
+            </select>
           </div>
           <div class="field"><label>Destination (blank = convert.dest from config)</label><input type="text" id="beet-conv-dest" placeholder="~/Music/Converted"></div>
           <div class="btn-row">
-            <button class="btn btn-primary" onclick="startConvert()">Run convert</button>
+            <button class="btn btn-primary" onclick="startConvert()">Check what would convert</button>
           </div>
           <div id="convert-job"></div>
           <hr class="divider">
@@ -1034,20 +1029,20 @@ document.addEventListener('keydown',function(e){
 // Only one job runs server-side at a time, so one runner here is enough.
 let jobRunner={es:null,id:null,el:null};
 
-function startJob(url,payload,elId){
+function startJob(url,payload,elId,onDone){
   const el=document.getElementById(elId);
   el.innerHTML='<div class="lib-empty">Starting…</div>';
   fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)})
     .then(r=>r.json())
     .then(data=>{
       if(!data.ok){el.innerHTML='<div class="alert alert-red">'+escapeHtml(data.error)+'</div>';return;}
-      attachJob(data.id,el);
+      attachJob(data.id,el,onDone);
     })
     .catch(()=>{el.innerHTML='<div class="lib-empty">Could not reach the server.</div>';});
 }
-function attachJob(id,el){
+function attachJob(id,el,onDone){
   if(jobRunner.es)jobRunner.es.close();
-  jobRunner={es:new EventSource('/jobs/'+id+'/events'),id:id,el:el};
+  jobRunner={es:new EventSource('/jobs/'+id+'/events'),id:id,el:el,onDone:onDone};
   el.innerHTML='<div class="lib-count" id="job-status">Working…</div>'+
     '<div class="btn-row"><button class="btn btn-danger btn-sm" onclick="abortJob()">Abort</button></div>';
   jobRunner.es.onmessage=e=>handleJobEvent(JSON.parse(e.data));
@@ -1082,9 +1077,28 @@ function handleJobEvent(ev){
     // An error already replaced the panel with its own message — keep it.
     if(!el.querySelector('.alert-red'))
       el.innerHTML='<div class="alert alert-green">'+escapeHtml(jobSummary(ev))+'</div>';
+    if(jobRunner.onDone)jobRunner.onDone(ev,el);
   }
 }
+// Fetch/embed have no pretend mode of their own to preview with (unlike
+// convert), so the preview step here is a /library/count check instead of
+// a dry-run job — same principle as previewModify()/runMaint(): show what
+// it would touch before an empty query quietly means "the whole library."
 function startArtwork(action){
+  const query=document.getElementById('art-query').value.trim();
+  const el=document.getElementById('artwork-job');
+  el.innerHTML='<div class="lib-empty">Checking…</div>';
+  fetch('/library/count?query='+encodeURIComponent(query))
+    .then(r=>r.json())
+    .then(data=>{
+      if(!data.ok){el.innerHTML='<div class="lib-empty">'+escapeHtml(data.error||'Could not check that query.')+'</div>';return;}
+      if(!data.count){el.innerHTML='<div class="lib-empty">No albums match'+(query?' that query':'')+'.</div>';return;}
+      const label=(action==='fetch'?'Fetch art for ':'Embed art into ')+data.count+' album'+(data.count===1?'':'s');
+      el.innerHTML='<div class="btn-row"><button class="btn btn-primary btn-sm" onclick="runArtwork(\''+action+'\')">'+label+'</button></div>';
+    })
+    .catch(()=>{el.innerHTML='<div class="lib-empty">Could not reach the server.</div>';});
+}
+function runArtwork(action){
   startJob('/artwork/start',{
     action:action,
     query:document.getElementById('art-query').value.trim(),
@@ -1482,12 +1496,24 @@ function countFormats(exts){
     })
     .catch(()=>{el.innerHTML='<div class="lib-empty">Could not reach the server.</div>';});
 }
+// Always previews first — the old "Preview only" checkbox meant a stray
+// uncheck ran ffmpeg for real with no warning beyond a confirm() popup.
+// Same shape as startArtwork()/runArtwork(): check step reveals the real
+// button, sized to what it's actually about to do.
 function startConvert(){
   const fmt=document.getElementById('beet-conv-fmt').value;
-  const pretend=document.getElementById('beet-conv-pretend').checked;
   const dest=document.getElementById('beet-conv-dest').value.trim();
-  if(!pretend&&!confirm('This runs ffmpeg and writes converted files to disk. Originals are left untouched. Continue?'))return;
-  startJob('/convert/start',{query:'format:'+fmt,pretend:pretend,dest:dest||null},'convert-job');
+  startJob('/convert/start',{query:'format:'+fmt,pretend:true,dest:dest||null},'convert-job',
+    (ev,el)=>{
+      if(!ev.total)return;
+      el.innerHTML+='<div class="btn-row"><button class="btn btn-warn btn-sm" onclick="runConvert()">Convert '+
+        ev.total+' track'+(ev.total===1?'':'s')+' for real</button></div>';
+    });
+}
+function runConvert(){
+  const fmt=document.getElementById('beet-conv-fmt').value;
+  const dest=document.getElementById('beet-conv-dest').value.trim();
+  startJob('/convert/start',{query:'format:'+fmt,pretend:false,dest:dest||null},'convert-job');
 }
 function buildXldCmd(){
   const src=document.getElementById('xld-src').value.trim()||'/path/to/file.wav';

--- a/beetsgui.html
+++ b/beetsgui.html
@@ -172,6 +172,7 @@
 
     <!-- INBOX -->
     <div id="tab-inbox" class="tab-panel active">
+      <div id="first-run-banner" style="display:none;"></div>
       <div class="section">
         <div class="section-title">
           <span>Scan for new music</span>
@@ -1312,6 +1313,31 @@ const COMMON_FIELDS=['artist','albumartist','album','title','genres','year',
 // Not metadata: the server rejects these (libops.PROTECTED_FIELDS) because
 // `path` redirects the tag write and `id`/`album_id` collide DB rows.
 const NON_FIELDS=['path','id','album_id'];
+// First-run nudge: an empty library is the honest signal that setup hasn't
+// happened yet (beets always has *some* config — its own defaults — so
+// "no config file" isn't a distinguishable state from the server's side).
+// Dismissal is per-session, not permanent: reloading after importing
+// nothing shouldn't need to ask again, but a genuinely fresh install should
+// keep asking until there's something in the library.
+function checkFirstRun(){
+  if(sessionStorage.getItem('firstRunDismissed')==='1')return;
+  fetch('/info/stats').then(r=>r.json()).then(data=>{
+    if(!data.ok||data.tracks>0)return;
+    document.getElementById('first-run-banner').outerHTML=
+      '<div class="alert alert-yellow" id="first-run-banner" style="margin-bottom:0.75rem;">'+
+      '<b>Your library is empty.</b> Set your music folder and pick metadata sources in '+
+      '<a href="#" onclick="openPrefs();return false;">Preferences</a> (⌘,), then scan or '+
+      'import a folder below.'+
+      '<div class="btn-row" style="margin-top:0.5rem;">'+
+      '<button class="btn btn-primary btn-sm" onclick="openPrefs()">Open Preferences</button>'+
+      '<button class="btn btn-sm" onclick="dismissFirstRun()">Dismiss</button>'+
+      '</div></div>';
+  }).catch(()=>{});
+}
+function dismissFirstRun(){
+  sessionStorage.setItem('firstRunDismissed','1');
+  document.getElementById('first-run-banner').style.display='none';
+}
 function loadModFields(){
   const sel=document.getElementById('mod-field');
   fetch('/info/fields').then(r=>r.json()).then(data=>{
@@ -1654,7 +1680,7 @@ function toggleBp4Method(){
   if(localStorage.getItem('cmdBoxOpen')==='1')box.open=true;
   box.addEventListener('toggle',()=>localStorage.setItem('cmdBoxOpen',box.open?'1':'0'));
 })();
-updatePathPreview();checkCurrentImport();loadModFields();
+updatePathPreview();checkCurrentImport();loadModFields();checkFirstRun();
 </script>
 </body>
 </html>

--- a/libops.py
+++ b/libops.py
@@ -168,6 +168,13 @@ def stats():
     }
 
 
+def album_count(query):
+    """How many albums a beets query matches — for a preview step before a
+    job that would otherwise run against the whole library unannounced."""
+    lib = get_library()
+    return len(list(lib.albums(split_query(query))))
+
+
 def fields():
     return {
         'item_fields': sorted(library.Item.all_keys()),

--- a/libops.py
+++ b/libops.py
@@ -10,6 +10,7 @@ confirm), so remove gets its own preview step here instead; same for
 modify, which beets only exposes via its interactive `modify_items`.
 """
 import io
+import re
 import shlex
 import threading
 from contextlib import redirect_stdout
@@ -24,6 +25,7 @@ from beets.ui.commands.update import update_items as _update_items
 from beets.ui.commands.utils import do_query
 from beets.ui.commands.write import write_items as _write_items
 from beets.util import displayable_path, functemplate
+from beets.util.deprecation import maybe_replace_legacy_field
 from beets.util.units import human_bytes, human_seconds
 
 from importsession import get_library
@@ -34,6 +36,13 @@ from importsession import get_library
 # single-flight (see importsession.py's docstring); this lock extends that
 # same discipline to console-capturing calls.
 _console_lock = threading.Lock()
+
+# beets colourises its diff output for a terminal, so the captured text
+# carries ANSI escapes that a browser renders as literal "[1;31m deleted".
+# Issue #11 deleted the old strip_ansi along with /run, correctly — it was
+# dead at the time. Capturing beets' own console output (added in #14)
+# brought the need back.
+_ANSI = re.compile(r'\x1b\[[0-9;]*m')
 
 
 # Fields that aren't metadata. `path` is the sharpest: setting it redirects
@@ -56,23 +65,34 @@ def split_query(query):
         raise UserError(f'could not parse query: {e}')
 
 
-def _check_field(field):
+def _resolve_field(field):
+    """Reject non-metadata fields, and translate beets' renamed ones.
+
+    beets 2.x renamed `genre`/`composer` to the list fields
+    `genres`/`composers` and ships `maybe_replace_legacy_field` for the
+    translation — its own `modify` command calls it. Without it, `genre`
+    parses as an unknown field, lands as a *flexible attribute*, and is then
+    filtered out by `write()` (which only writes `_media_fields`), so the
+    caller is told N items changed while nothing reaches the files.
+    """
     if field in PROTECTED_FIELDS:
         raise UserError(f'{field} is not an editable metadata field')
+    return maybe_replace_legacy_field(field, False, modify=True)
 
 
 def _capture(fn, *args, **kwargs):
     buf = io.StringIO()
     with _console_lock, redirect_stdout(buf):
         fn(*args, **kwargs)
-    return [line for line in buf.getvalue().splitlines() if line]
+    return [_ANSI.sub('', line).rstrip()
+            for line in buf.getvalue().splitlines() if line.strip()]
 
 
 # ── modify ───────────────────────────────────────────────────────────────
 
 def preview_modify(field, value, query):
     """Items the query matches, with their current and would-be new value."""
-    _check_field(field)
+    field = _resolve_field(field)
     lib = get_library()
     items = list(lib.items(split_query(query)))
     template = functemplate.template(value)
@@ -88,7 +108,7 @@ def preview_modify(field, value, query):
 
 def apply_modify(field, value, query):
     """Apply the change previewed by preview_modify(). Returns count changed."""
-    _check_field(field)
+    field = _resolve_field(field)
     lib = get_library()
     items = list(lib.items(split_query(query)))
     template = functemplate.template(value)

--- a/server.py
+++ b/server.py
@@ -337,6 +337,16 @@ def library_missing():
     return jsonify({'ok': True, 'albums': libops.missing_albums()})
 
 
+@app.route('/library/count')
+def library_count():
+    """Albums a beets query matches — the preview step before artwork/sync
+    jobs, which have no pretend mode of their own to preview with."""
+    try:
+        return jsonify({'ok': True, 'count': libops.album_count(request.args.get('query', ''))})
+    except UserError as e:
+        return jsonify({'ok': False, 'error': str(e)}), 400
+
+
 @app.route('/library/remove/preview', methods=['POST'])
 def library_remove_preview():
     """Body: {"query": "..."}."""


### PR DESCRIPTION
Phase 0 of #36 — the UI changes that needed no design debate. Two real bugs fell out of the first one.

> **Stacked on #31.** Base is `harden-endpoints-29`, not `master`, because both touch `beetsgui.html`. Merge #31 first and this becomes a clean diff against master.

## Field is a dropdown, not free text

Built from `/info/fields` (already called elsewhere in the UI), common tagging fields first, then the remaining ~90 under an `other fields` group. Nobody knows beets' 100 item-field names, and the free-text box couldn't tell you.

It also can no longer produce the `path`/`id`/`album_id` values that `libops.PROTECTED_FIELDS` exists to reject — the blocklist stays as the API-level guard, but the UI no longer offers the foot-gun.

## Bug 1: `genre` was never editable

Building that list is what exposed it. beets 2.x renamed `genre`/`composer` to the list fields `genres`/`composers` and ships `maybe_replace_legacy_field` for the translation. Its own `modify` command calls it. `libops` did not.

So `genre` parsed as an *unknown* field, landed as a **flexible attribute**, and was then filtered out by `write()`, which only writes `_media_fields`. The UI said "Changed N items" and nothing reached the files.

```
genre    -> genres    in _media_fields: True   (before: stayed 'genre')
composer -> composers in _media_fields: True   (before: stayed 'composer')
'genre' itself in _media_fields: False         <- why it silently did nothing
```

`libops` now resolves legacy names before use; the dropdown offers the plural forms.

## Bug 2: ANSI escapes rendered as literal text

The browser was showing `ESC[1;31m  deleted ESC[39;49;00m` as visible characters. Issue #11 deleted `strip_ansi` along with `/run` — correctly, it was dead at the time. Capturing beets' own console output in #14 brought the need back, and nothing noticed. `libops._capture` now strips escapes:

```
before: ["Gone Artist - Gone Album - Ghost Track", "<ESC>[1;31m  deleted<ESC>[39;49;00m"]
after:  ["Gone Artist - Gone Album - Ghost Track", "  deleted"]
```

## Update/write are two-step

They were a "Preview update" button sitting next to an "Apply update" button you could click without ever previewing — structurally the same problem as `/library/remove` in #29. Apply now only exists once a preview has shown what it would do, matching the existing `previewModify`/`applyModify` shape.

## Copy

"Preview only (--pretend)" no longer names a CLI flag.

## Verified

In the browser against a scratch library (`BEETSDIR` in a temp dir, never the real one):

- dropdown offers `genres`, does not offer `genre`, and excludes all three protected fields
- `runUpdate()` renders the diff plus an `Update the library` button wired to `runMaint('update',true)`
- captured output contains no ANSI escapes
- full `test_importsession.py` passes; both `<script>` blocks pass `node --check`

## Not in this PR

Phases 1-4 of #36: convert/artwork two-step, one activity surface, structured filters instead of query strings, naming pass. Also noted there: unknown field names still become flexible attributes at the API level, which is a validation decision rather than a UI one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
