### PR TITLE
Stability hardening: honest abort, bounded queue, SSE fan-out, scan budget (#32-#35)

### DIFF
--- a/beetsgui.html
+++ b/beetsgui.html
@@ -103,6 +103,11 @@
   .lib-row-meta { color:var(--text3); font-size:10px; letter-spacing:0.04em; white-space:nowrap; }
   .lib-empty { color:var(--text3); font-size:12px; padding:1.5rem; text-align:center; }
   .lib-count { color:var(--text3); font-size:10px; letter-spacing:0.06em; text-transform:uppercase; margin-bottom:0.5rem; }
+  /* Indeterminate progress cue for a running background job — the app can't
+     show a real percentage (mbsync/bpsync don't report counts at all), so
+     this signals "still alive" rather than "how far along." */
+  @keyframes job-pulse { 0%,100% { opacity:1; } 50% { opacity:0.45; } }
+  .job-pulse { animation:job-pulse 1.6s ease-in-out infinite; }
   details.section summary.section-title { cursor:pointer; user-select:none; }
   details.section summary.section-title::-webkit-details-marker { color:var(--text3); }
   .kbd { background:var(--bg3); border:1px solid var(--border2); border-radius:3px; color:var(--text3); font-size:9px; padding:0.05rem 0.3rem; margin-right:0.35rem; }
@@ -1051,12 +1056,29 @@ function startJob(url,payload,elId){
 function attachJob(id,el){
   if(jobRunner.es)jobRunner.es.close();
   jobRunner={es:new EventSource('/jobs/'+id+'/events'),id:id,el:el};
-  el.innerHTML='<div class="lib-count" id="job-status">Working…</div>'+
-    '<div class="btn-row"><button class="btn btn-danger btn-sm" onclick="abortJob()">Abort</button></div>';
+  el.innerHTML='<div class="lib-count job-pulse" id="job-status">Working…</div>'+
+    '<div class="btn-row"><button class="btn btn-danger btn-sm" id="job-abort-btn" onclick="abortJob()">Abort</button></div>';
   jobRunner.es.onmessage=e=>handleJobEvent(JSON.parse(e.data));
 }
+// mbsync/bpsync only checkpoint between phases, not between items within a
+// phase (see server.py's /jobs/<id>/abort docstring) — a click here can
+// legitimately sit for minutes with no SSE event. Give feedback immediately
+// instead of leaving the last status line frozen with no sign anything
+// happened, and say so honestly if the wait times out rather than going
+// quiet again.
 function abortJob(){
-  if(jobRunner.id)fetch('/jobs/'+jobRunner.id+'/abort',{method:'POST'});
+  if(!jobRunner.id)return;
+  const status=document.getElementById('job-status');
+  const btn=document.getElementById('job-abort-btn');
+  if(btn)btn.disabled=true;
+  if(status)status.textContent='Aborting — waiting for the current step to finish…';
+  fetch('/jobs/'+jobRunner.id+'/abort',{method:'POST'})
+    .then(r=>r.json())
+    .then(data=>{
+      if(!data.finished&&status)
+        status.textContent='Still finishing ('+data.kind+') — this can take a few more minutes; the page updates on its own once it does.';
+    })
+    .catch(()=>{});
 }
 function jobSummary(ev){
   const parts=[];

--- a/beetsgui.html
+++ b/beetsgui.html
@@ -1428,7 +1428,7 @@ function findFormat(ext){
     .then(data=>{
       if(!data.ok){el.innerHTML='<div class="lib-empty">'+escapeHtml(data.error||'Failed.')+'</div>';return;}
       if(!data.files.length){el.innerHTML='<div class="lib-empty">No '+ext.toUpperCase()+' files found.</div>';return;}
-      el.innerHTML='<div class="lib-count">'+data.files.length+' file'+(data.files.length===1?'':'s')+'</div>'+
+      el.innerHTML=truncNote(data)+'<div class="lib-count">'+data.files.length+' file'+(data.files.length===1?'':'s')+'</div>'+
         '<div class="lib-results">'+data.files.map(f=>'<div class="lib-row"><div class="lib-row-title">'+escapeHtml(f)+'</div></div>').join('')+'</div>';
     })
     .catch(()=>{el.innerHTML='<div class="lib-empty">Could not reach the server.</div>';});
@@ -1441,7 +1441,7 @@ function countFormats(exts){
   fetch('/scan/count?dir='+encodeURIComponent(src)+'&ext='+exts+'&exclude=Samples,Stems')
     .then(r=>r.json())
     .then(data=>{
-      el.innerHTML=data.ok?'<div class="lib-empty">'+data.total_files+' file'+(data.total_files===1?'':'s')+'</div>':'<div class="lib-empty">'+escapeHtml(data.error||'Failed.')+'</div>';
+      el.innerHTML=data.ok?truncNote(data)+'<div class="lib-empty">'+data.total_files+' file'+(data.total_files===1?'':'s')+'</div>':'<div class="lib-empty">'+escapeHtml(data.error||'Failed.')+'</div>';
     })
     .catch(()=>{el.innerHTML='<div class="lib-empty">Could not reach the server.</div>';});
 }
@@ -1460,6 +1460,12 @@ function buildXldCmd(){
   if(mode==='single')setCmd('xld -f '+fmt+' -o "'+out+'" "'+src+'"');
   else{const ext=fmt==='aiff'?'aiff':'wav';setCmd('fd -e '+ext+' . "'+src+'" --exclude Samples --exclude Stems | while read f; do xld -f '+fmt+' -o "'+out+'" "$f"; done');}
 }
+// Server gives up on a scan after a wall-clock budget (#35) rather than
+// running forever on a huge dir — say so, or a partial count/list quietly
+// looks like the whole truth.
+function truncNote(data){
+  return data.truncated?'<div class="alert alert-yellow" style="font-size:10px;">Stopped early — this folder is large enough that the count/list above is incomplete.</div>':'';
+}
 function scanDir(){return document.getElementById('scan-path').value.trim();}
 function scanExclude(){return Array.from(document.querySelectorAll('#scan-excl input:checked')).map(c=>c.value).join(',');}
 function fmtBytes(n){
@@ -1475,7 +1481,7 @@ function scanCount(){
   fetch('/scan/count?dir='+encodeURIComponent(dir)+'&exclude='+encodeURIComponent(scanExclude()))
     .then(r=>r.json())
     .then(data=>{
-      el.innerHTML=data.ok?'<div class="lib-empty">'+data.total_files+' file'+(data.total_files===1?'':'s')+'</div>':'<div class="lib-empty">'+escapeHtml(data.error||'Failed.')+'</div>';
+      el.innerHTML=data.ok?truncNote(data)+'<div class="lib-empty">'+data.total_files+' file'+(data.total_files===1?'':'s')+'</div>':'<div class="lib-empty">'+escapeHtml(data.error||'Failed.')+'</div>';
     })
     .catch(()=>{el.innerHTML='<div class="lib-empty">Could not reach the server.</div>';});
 }
@@ -1486,7 +1492,7 @@ function scanSaveList(){
   fetch('/scan/save-list',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({dir,exclude:scanExclude()})})
     .then(r=>r.json())
     .then(data=>{
-      el.innerHTML=data.ok?'<div class="alert alert-green">Saved '+data.count+' file'+(data.count===1?'':'s')+' to '+escapeHtml(data.path)+'</div>':'<div class="lib-empty">'+escapeHtml(data.error||'Failed.')+'</div>';
+      el.innerHTML=data.ok?truncNote(data)+'<div class="alert alert-green">Saved '+data.count+' file'+(data.count===1?'':'s')+' to '+escapeHtml(data.path)+'</div>':'<div class="lib-empty">'+escapeHtml(data.error||'Failed.')+'</div>';
     })
     .catch(()=>{el.innerHTML='<div class="lib-empty">Could not reach the server.</div>';});
 }
@@ -1499,7 +1505,7 @@ function scanSizes(){
     .then(data=>{
       if(!data.ok){el.innerHTML='<div class="lib-empty">'+escapeHtml(data.error||'Failed.')+'</div>';return;}
       if(!data.folders.length){el.innerHTML='<div class="lib-empty">No subfolders found.</div>';return;}
-      el.innerHTML='<div class="lib-results">'+data.folders.map(f=>
+      el.innerHTML=truncNote(data)+'<div class="lib-results">'+data.folders.map(f=>
         '<div class="lib-row"><div class="lib-row-title">'+escapeHtml(f.path)+'</div><div class="lib-row-meta">'+fmtBytes(f.size_bytes)+'</div></div>'
       ).join('')+'</div>';
     })

--- a/importsession.py
+++ b/importsession.py
@@ -194,8 +194,8 @@ class ImportJob(jobs.Job):
         self._pending = None
 
     def summary(self):
-        return {'id': self.id, 'kind': self.kind, 'paths': self.paths,
-                'mode': self.mode, 'handling': self.handling,
+        return {'id': self.id, 'kind': self.kind, 'aborting': self.aborted.is_set(),
+                'paths': self.paths, 'mode': self.mode, 'handling': self.handling,
                 'incremental': self.incremental, 'singleton': self.singleton}
 
     # -- called from importer threads --

--- a/jobs.py
+++ b/jobs.py
@@ -23,18 +23,38 @@ import uuid
 class Job:
     """A background operation with an SSE event stream."""
 
+    # Bounds memory to a constant regardless of library size when nobody's
+    # listening (tab closed, SSE dropped) — status events are progress, not
+    # state, so losing the oldest ones is fine. A reconnecting client
+    # re-syncs via /jobs/current and replay() rather than the queue's
+    # contents, so this holds even for ImportJob's decisions (see
+    # importsession.py: the pending decision's source of truth is
+    # self._pending, not this queue — replay() never reads from here).
+    _MAX_BUFFERED_EVENTS = 200
+
     def __init__(self, kind, **meta):
         self.id = uuid.uuid4().hex
         self.kind = kind
         self.meta = meta
-        self.events = queue.Queue()
+        self.events = queue.Queue(maxsize=self._MAX_BUFFERED_EVENTS)
         self.done = threading.Event()
         self.aborted = threading.Event()
         self.result = {}      # merged into the final 'done' event
         self.thread = None
 
     def emit(self, type, **payload):
-        self.events.put({'type': type, **payload})
+        """Never blocks the worker thread: if the buffer is full (nobody's
+        draining it), drop the oldest event to make room instead of
+        waiting for a consumer that may never show up."""
+        event = {'type': type, **payload}
+        try:
+            self.events.put_nowait(event)
+        except queue.Full:
+            try:
+                self.events.get_nowait()
+            except queue.Empty:
+                pass
+            self.events.put_nowait(event)
 
     def replay(self):
         """Events a reconnecting client must be given immediately.

--- a/jobs.py
+++ b/jobs.py
@@ -10,10 +10,11 @@ registry here is deliberately global and single-flight: the invariant is
 "one beets job at a time", not "one import at a time", which is why
 import doesn't get a registry of its own.
 
-A job owns a thread, an event queue drained by an SSE endpoint, and an
-abort flag. Abort is cooperative: the worker checks `job.aborted` between
-units of work. Only import can also be blocked mid-unit waiting on a
-human, so only `ImportJob` overrides `abort()` to unblock that wait.
+A job owns a thread, a fan-out set of per-listener event queues (one per
+connected SSE stream — see subscribe()/unsubscribe()), and an abort flag.
+Abort is cooperative: the worker checks `job.aborted` between units of
+work. Only import can also be blocked mid-unit waiting on a human, so
+only `ImportJob` overrides `abort()` to unblock that wait.
 """
 import queue
 import threading
@@ -36,25 +37,47 @@ class Job:
         self.id = uuid.uuid4().hex
         self.kind = kind
         self.meta = meta
-        self.events = queue.Queue(maxsize=self._MAX_BUFFERED_EVENTS)
+        # One queue per connected SSE stream, not one shared queue — two
+        # tabs open on the same job each got a *subset* of events before
+        # (both calling .get() on one queue splits the stream between them)
+        # rather than each seeing the full thing. See subscribe()/unsubscribe().
+        self._listeners = []
+        self._listeners_lock = threading.Lock()
         self.done = threading.Event()
         self.aborted = threading.Event()
         self.result = {}      # merged into the final 'done' event
         self.thread = None
 
+    def subscribe(self):
+        """Register a new listener queue for this job. Call unsubscribe()
+        with the returned queue when the connection ends."""
+        q = queue.Queue(maxsize=self._MAX_BUFFERED_EVENTS)
+        with self._listeners_lock:
+            self._listeners.append(q)
+        return q
+
+    def unsubscribe(self, q):
+        with self._listeners_lock:
+            if q in self._listeners:
+                self._listeners.remove(q)
+
     def emit(self, type, **payload):
-        """Never blocks the worker thread: if the buffer is full (nobody's
-        draining it), drop the oldest event to make room instead of
-        waiting for a consumer that may never show up."""
+        """Fan out to every connected listener. Never blocks the worker
+        thread: if a listener's buffer is full (a slow or gone consumer),
+        drop that listener's oldest event to make room rather than waiting
+        for a consumer that may never show up."""
         event = {'type': type, **payload}
-        try:
-            self.events.put_nowait(event)
-        except queue.Full:
+        with self._listeners_lock:
+            listeners = list(self._listeners)
+        for q in listeners:
             try:
-                self.events.get_nowait()
-            except queue.Empty:
-                pass
-            self.events.put_nowait(event)
+                q.put_nowait(event)
+            except queue.Full:
+                try:
+                    q.get_nowait()
+                except queue.Empty:
+                    pass
+                q.put_nowait(event)
 
     def replay(self):
         """Events a reconnecting client must be given immediately.

--- a/jobs.py
+++ b/jobs.py
@@ -49,7 +49,8 @@ class Job:
         self.aborted.set()
 
     def summary(self):
-        return {'id': self.id, 'kind': self.kind, **self.meta}
+        return {'id': self.id, 'kind': self.kind, 'aborting': self.aborted.is_set(),
+                **self.meta}
 
 
 # ── Registry ──────────────────────────────────────────────────────────────

--- a/server.py
+++ b/server.py
@@ -734,33 +734,39 @@ def jobs_current():
 
 @app.route('/jobs/<job_id>/events')
 def job_events(job_id):
-    """SSE stream of status, decision and done events. One consumer at a time."""
+    """SSE stream of status, decision and done events. Each connection gets
+    its own fan-out queue (jobs.py), so multiple tabs each see the complete
+    stream instead of splitting one shared queue between them."""
     job = jobs.get(job_id)
     if not job:
         return jsonify({'ok': False, 'error': 'unknown job id'}), 404
 
     def generate():
-        # A reconnecting client must not have to wait out the decision timeout,
-        # so replay whatever the job says it owes a fresh listener (only
-        # import has anything) — but send each decision only once, since the
-        # queue may still hold the copy this replaces.
-        sent = set()
-        for event in job.replay():
-            sent.add(event['decision_id'])
-            yield f"data: {json.dumps(event)}\n\n"
-        while True:
-            try:
-                event = job.events.get(timeout=15)
-            except queue.Empty:
-                yield ": keepalive\n\n"
-                continue
-            if event['type'] == 'decision':
-                if event['decision_id'] in sent:
-                    continue
+        q = job.subscribe()
+        try:
+            # A reconnecting client must not have to wait out the decision
+            # timeout, so replay whatever the job says it owes a fresh
+            # listener (only import has anything) — but send each decision
+            # only once, since the queue may still hold the copy this replaces.
+            sent = set()
+            for event in job.replay():
                 sent.add(event['decision_id'])
-            yield f"data: {json.dumps(event)}\n\n"
-            if event['type'] == 'done':
-                return
+                yield f"data: {json.dumps(event)}\n\n"
+            while True:
+                try:
+                    event = q.get(timeout=15)
+                except queue.Empty:
+                    yield ": keepalive\n\n"
+                    continue
+                if event['type'] == 'decision':
+                    if event['decision_id'] in sent:
+                        continue
+                    sent.add(event['decision_id'])
+                yield f"data: {json.dumps(event)}\n\n"
+                if event['type'] == 'done':
+                    return
+        finally:
+            job.unsubscribe(q)
 
     return Response(generate(), mimetype='text/event-stream', headers={
         'Cache-Control':     'no-cache',

--- a/server.py
+++ b/server.py
@@ -449,10 +449,22 @@ def _parse_exclude(raw):
     return [e.strip().lower() for e in (raw or '').split(',') if e.strip()]
 
 
-def _scan_files(dir_path, exclude, exts=None):
+# A caller-named huge root (or one huge immediate subfolder under it) is
+# intended use, not a bug — but a request that never returns, with no way
+# to cancel, is a real usability failure regardless of intent (#35). A
+# wall-clock budget shared across the whole request turns "forever" into
+# "a few seconds with a truncated flag," which is all this needs to be.
+_SCAN_BUDGET_SECONDS = 10
+
+
+def _scan_files(dir_path, exclude, exts=None, deadline=None, truncated=None):
     """Audio files under dir_path, matching `exts` (default:
     AUDIO_EXTENSIONS) and not matching any exclude substring — same
     filter /unimported already uses.
+
+    `deadline` (a time.monotonic() timestamp) stops the walk once passed;
+    `truncated`, if given a list, gets `True` appended so the caller can
+    tell "found everything" apart from "gave up".
 
     ponytail: Path.rglob has no documented guarantee against FIFOs or
     symlink loops on a user-supplied tree. /unimported's use of the same
@@ -462,11 +474,27 @@ def _scan_files(dir_path, exclude, exts=None):
     exts = exts or AUDIO_EXTENSIONS
     root = Path(dir_path)
     for f in root.rglob('*'):
+        if deadline and time.monotonic() > deadline:
+            if truncated is not None:
+                truncated.append(True)
+            return
         if not f.is_file() or f.suffix.lower() not in exts:
             continue
         if exclude and any(e in str(f).lower() for e in exclude):
             continue
         yield f
+
+
+def _sized_or_truncated(paths, deadline):
+    """Sum file sizes under `paths`, stopping early past `deadline`.
+    Returns (total_bytes, hit_deadline)."""
+    total = 0
+    for f in paths:
+        if time.monotonic() > deadline:
+            return total, True
+        if f.is_file():
+            total += f.stat().st_size
+    return total, False
 
 
 def _walk_roots(dir_path):
@@ -500,8 +528,10 @@ def scan_count():
         return jsonify({'ok': False, 'error': 'no such directory'}), 400
     exclude = _parse_exclude(request.args.get('exclude', ''))
     exts = _parse_exts(request.args.get('ext', ''))
-    total = sum(1 for _ in _scan_files(dir_path, exclude, exts))
-    return jsonify({'ok': True, 'total_files': total})
+    truncated = []
+    deadline = time.monotonic() + _SCAN_BUDGET_SECONDS
+    total = sum(1 for _ in _scan_files(dir_path, exclude, exts, deadline, truncated))
+    return jsonify({'ok': True, 'total_files': total, 'truncated': bool(truncated)})
 
 
 @app.route('/scan/list')
@@ -513,8 +543,10 @@ def scan_list():
         return jsonify({'ok': False, 'error': 'no such directory'}), 400
     exclude = _parse_exclude(request.args.get('exclude', ''))
     exts = _parse_exts(request.args.get('ext', ''))
-    files = sorted(str(f) for f in _scan_files(dir_path, exclude, exts))
-    return jsonify({'ok': True, 'files': files})
+    truncated = []
+    deadline = time.monotonic() + _SCAN_BUDGET_SECONDS
+    files = sorted(str(f) for f in _scan_files(dir_path, exclude, exts, deadline, truncated))
+    return jsonify({'ok': True, 'files': files, 'truncated': bool(truncated)})
 
 
 @app.route('/scan/save-list', methods=['POST'])
@@ -527,11 +559,13 @@ def scan_save_list():
         return jsonify({'ok': False, 'error': 'no such directory'}), 400
     exclude = _parse_exclude(data.get('exclude', ''))
     dest = (data.get('dest') or '~/Desktop/music_list.txt').strip()
-    files = sorted(str(f) for f in _scan_files(dir_path, exclude))
+    truncated = []
+    deadline = time.monotonic() + _SCAN_BUDGET_SECONDS
+    files = sorted(str(f) for f in _scan_files(dir_path, exclude, deadline=deadline, truncated=truncated))
     path, error = _write_list(dest, files)
     if error:
         return jsonify({'ok': False, 'error': error}), 400
-    return jsonify({'ok': True, 'count': len(files), 'path': str(path)})
+    return jsonify({'ok': True, 'count': len(files), 'path': str(path), 'truncated': bool(truncated)})
 
 
 @app.route('/scan/sizes')
@@ -541,11 +575,19 @@ def scan_sizes():
     dir_path = os.path.expanduser(request.args.get('dir', '').strip())
     if not dir_path or not os.path.isdir(dir_path):
         return jsonify({'ok': False, 'error': 'no such directory'}), 400
+    deadline = time.monotonic() + _SCAN_BUDGET_SECONDS
     folders = []
+    truncated = False
     for sub in _walk_roots(dir_path):
-        size = sum(f.stat().st_size for f in sub.rglob('*') if f.is_file())
+        if time.monotonic() > deadline:
+            truncated = True
+            break
+        size, hit_deadline = _sized_or_truncated(sub.rglob('*'), deadline)
         folders.append({'path': str(sub), 'size_bytes': size})
-    return jsonify({'ok': True, 'folders': folders})
+        if hit_deadline:
+            truncated = True
+            break
+    return jsonify({'ok': True, 'folders': folders, 'truncated': truncated})
 
 
 # The XML library file only ever exists here — iTunes/Music.app write it

--- a/server.py
+++ b/server.py
@@ -772,13 +772,20 @@ def job_events(job_id):
 @app.route('/jobs/<job_id>/abort', methods=['POST'])
 def job_abort(job_id):
     """Cancel the job. Abort is cooperative — the worker stops at its next
-    checkpoint, so this waits for the job to actually finish."""
+    checkpoint, so this waits for the job to actually finish.
+
+    mbsync/bpsync (sync.py) checkpoint only between their two phases, not
+    between items within a phase — each phase is one plain `for` loop inside
+    the beets plugin itself, with no hook to interrupt mid-loop without
+    duplicating its matching logic. So this can legitimately time out with
+    the job still running; `finished: false` is a true answer, not a bug,
+    and the caller is expected to say so rather than imply it's stuck."""
     job = jobs.get(job_id)
     if not job:
         return jsonify({'ok': False, 'error': 'unknown job id'}), 404
     job.abort()
     job.done.wait(timeout=30)
-    return jsonify({'ok': True, 'finished': job.done.is_set()})
+    return jsonify({'ok': True, 'finished': job.done.is_set(), **job.summary()})
 
 
 @app.route('/import/<job_id>/decide', methods=['POST'])


### PR DESCRIPTION
Closes #33, #34, #35. Partially addresses #32 (left open — see below).

Four bounded fixes to the job/SSE plumbing flagged during #29's adversarial pass but out of that PR's scope. Each confirmed against real code before fixing, not assumed from the original issue text.

## #32 — abort honesty, not true interruption
Read `beetsplug/mbsync.py`'s actual source before implementing: `singletons()`/`albums()` are plain for-loops with no hook to interrupt mid-loop without duplicating the plugin's matching logic — the exact trade `sync.py`'s own comment already rejected once, now confirmed rather than assumed. Shipped the honest half (visible "aborting" state, immediate UI feedback, truthful timeout messaging) — not the second goal metric (a new job starting immediately after abort), which would need either that duplication or accepting the concurrent-mutation risk #29 exists to prevent. **Left open** — the gap is real and documented on the issue.

## #33 — bounded, drop-oldest event queue
Checked `importsession.py` before implementing: a pending decision's source of truth is `self._pending`, never the events queue — so a uniform drop-oldest policy needed no ImportJob special-case, simpler than the issue anticipated. `queue.Queue(maxsize=200)` via `put_nowait()` + evict-on-`Full`, never blocking the worker.

## #34 — fan-out instead of takeover
Went with per-connection listener queues over the issue's suggested "takeover" — no smaller once #33 established the bounded/drop-oldest pattern, and no staleness window (takeover needs the superseded connection to notice, lagging up to the 15s keepalive).

## #35 — wall-clock budget, not the job engine
Budget + `truncated` flag, not moving scan endpoints onto the job engine (the issue's own second option) — disproportionate for something the report calls low-priority and self-inflicted. `/scan/save-list` picked up the same fix for free (shares `_scan_files`, wasn't named in the issue but has the identical risk). Also surfaced `truncated` in the UI — a partial count silently read as complete otherwise.

## Verified

Every fix has a runnable check beyond code review — synthetic slow jobs through the real Flask routes (test client, not mocked), concurrent SSE connections, a scaled-down budget against a real 3000-file tree, live browser checks for the two UI-visible pieces. `test_importsession.py` passes on the final tree. Full reasoning and verification output for each is on its respective issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
