### PR TITLE
Fix CI: beets 2.13 moved AlbumMatch; pin test.yml, add weekly canary

### DIFF
--- a/.github/workflows/beets-canary.yml
+++ b/.github/workflows/beets-canary.yml
@@ -1,0 +1,31 @@
+name: Beets compatibility canary
+
+# Runs against latest beets, independently of test.yml (which is pinned to
+# the version this app is actually developed against). A failure here means
+# "beets changed something," not "this PR is broken" — that's a different
+# signal and shouldn't block anyone's PR. Runs weekly so upstream breakage
+# is caught even when nobody's actively touching the repo, not just
+# whenever the next PR happens to come along.
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # every Monday, 06:00 UTC
+  workflow_dispatch:        # manual "run it now" from the Actions tab
+
+jobs:
+  test_importsession_latest_beets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Install dependencies (latest beets, unpinned)
+        run: pip install beets flask
+
+      - name: Run test_importsession.py
+        run: python test_importsession.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
       - name: Install dependencies
-        run: pip install beets flask
+        # Pinned to the version this app is actually developed/run against
+        # (~/.local/pipx/venvs/beets locally) — a red run here should mean
+        # "this PR broke something," not "beets shipped a new release."
+        # See .github/workflows/beets-canary.yml for the latter.
+        run: pip install beets==2.11.0 flask
 
       - name: Run test_importsession.py
         run: python test_importsession.py

--- a/importsession.py
+++ b/importsession.py
@@ -21,7 +21,10 @@ import threading
 import uuid
 
 from beets import config, context, plugins, ui
-from beets.autotag.hooks import AlbumMatch
+try:
+    from beets.autotag.match import AlbumMatch   # beets >= 2.13
+except ImportError:
+    from beets.autotag.hooks import AlbumMatch    # beets < 2.13
 from beets.importer import Action, ImportAbortError, ImportSession
 from beets.util import displayable_path
 


### PR DESCRIPTION
Every previous CI run had failed. First cause was GitHub's own queue outage (unrelated, already documented on #28's thread). Once that cleared, the actual cause turned out to be real: unpinned `pip install beets` on `test.yml` always grabs latest, and beets 2.13 moved `AlbumMatch` from `beets.autotag.hooks` to `beets.autotag.match`. This is the first time CI has ever gotten far enough to hit real test execution rather than an infra failure.

## Fix

- `importsession.py`: try the new import location, fall back to the old one. Verified working under **both** beets 2.11.0 (the actual local pipx install this app is developed against) and 2.13.1 (a fresh venv built to match CI exactly).
- `test.yml`: pin `beets==2.11.0`. A red run here should mean "this PR broke something," not "beets shipped a release" — conflating those is close to what just happened, and a CI that cries wolf on unrelated upstream changes stops being trusted.
- `beets-canary.yml` (new): scheduled weekly + manual dispatch, against unpinned/latest beets, kept separate from the PR-gating workflow so a canary failure never blocks a PR. This is the actual mechanism for catching the *next* upstream break early instead of finding out from a confusing "server died" with no stderr.

## Found, not fixed here

Running the full suite under beets 2.13.1 surfaces a **second**, deeper incompatibility: `test.js`... `test_importsession.py`'s `main()` asserts a lossless duplicate of a lossy album should still prompt the user, and under 2.13.1 it doesn't (`dup` comes back `None`). That's a real behavioral difference in beets' own duplicate-handling path between versions, not a one-line import fix — filed as its own issue rather than rushed into this PR.

## Verified

- `server.py`'s full import chain succeeds under both beets versions (checked directly, not just via the test suite)
- `test_importsession.py` passes end-to-end under beets 2.11.0 (both before and after this fix — no regression)
- Both workflow YAML files parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)
