### PR TITLE
Build against beets 2.13.1: fix duplicate detection and convert

### DIFF
--- a/.github/workflows/beets-canary.yml
+++ b/.github/workflows/beets-canary.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Run test_importsession.py
         run: python test_importsession.py
+
+      - name: Run test_transcode.py
+        run: python test_transcode.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,14 @@ jobs:
 
       - name: Install dependencies
         # Pinned to the version this app is actually developed/run against
-        # (~/.local/pipx/venvs/beets locally) — a red run here should mean
-        # "this PR broke something," not "beets shipped a new release."
-        # See .github/workflows/beets-canary.yml for the latter.
-        run: pip install beets==2.11.0 flask
+        # (decided in #47: 2.13.1, the latest stable at the time) — a red
+        # run here should mean "this PR broke something," not "beets
+        # shipped a new release." See .github/workflows/beets-canary.yml
+        # for the latter.
+        run: pip install beets==2.13.1 flask
 
       - name: Run test_importsession.py
         run: python test_importsession.py
+
+      - name: Run test_transcode.py
+        run: python test_transcode.py

--- a/importsession.py
+++ b/importsession.py
@@ -25,6 +25,10 @@ try:
     from beets.autotag.match import AlbumMatch   # beets >= 2.13
 except ImportError:
     from beets.autotag.hooks import AlbumMatch    # beets < 2.13
+try:
+    from beets.importer import DuplicateAction    # beets >= 2.13
+except ImportError:
+    DuplicateAction = None                        # beets < 2.13
 from beets.importer import Action, ImportAbortError, ImportSession
 from beets.util import displayable_path
 
@@ -354,7 +358,11 @@ class WebImportSession(ImportSession):
     # Singletons take the same payload shape; serialize_task handles both.
     choose_item = choose_match
 
-    def resolve_duplicate(self, task, found_duplicates):
+    def _decide_duplicate(self, task, found_duplicates):
+        """Shared logic behind both beets duplicate-resolution APIs below.
+
+        Returns 'skip', 'keep', 'remove' or 'merge'.
+        """
         items = task.imported_items()
         chosen = task.chosen_info()
 
@@ -372,8 +380,7 @@ class WebImportSession(ImportSession):
         if new_rank < existing_rank:
             self.job.emit('status', message=(
                 'Auto-skip: an existing copy is higher quality'))
-            task.set_choice(Action.SKIP)
-            return
+            return 'skip'
 
         payload = {
             'kind':      'duplicate',
@@ -390,14 +397,32 @@ class WebImportSession(ImportSession):
         if new_rank > existing_rank:
             payload['recommendation'] = 'remove'
         reply = self.job.ask(payload)
-        choice = reply['choice']
-        if choice == 'skip':
-            task.set_choice(Action.SKIP)
-        elif choice == 'remove':
-            task.should_remove_duplicates = True
-        elif choice == 'merge':
-            task.should_merge_duplicates = True
-        # 'keep': leave the choice intact.
+        return reply['choice']
+
+    if DuplicateAction is not None:
+        # beets >= 2.13: ImportSession.resolve_duplicate was replaced by
+        # get_duplicate_action, which returns the decision instead of
+        # mutating the task — beets' own pipeline now does the
+        # skip/remove/merge dispatch (see importer/stages.py).
+        def get_duplicate_action(self, task, found_duplicates):
+            choice = self._decide_duplicate(task, found_duplicates)
+            return {
+                'skip':   DuplicateAction.SKIP,
+                'keep':   DuplicateAction.KEEP,
+                'remove': DuplicateAction.REMOVE,
+                'merge':  DuplicateAction.MERGE,
+            }[choice]
+    else:
+        # beets < 2.13: resolve_duplicate mutates the task directly.
+        def resolve_duplicate(self, task, found_duplicates):
+            choice = self._decide_duplicate(task, found_duplicates)
+            if choice == 'skip':
+                task.set_choice(Action.SKIP)
+            elif choice == 'remove':
+                task.should_remove_duplicates = True
+            elif choice == 'merge':
+                task.should_merge_duplicates = True
+            # 'keep': leave the choice intact.
 
 
 # ── Library and config ────────────────────────────────────────────────────────

--- a/test_transcode.py
+++ b/test_transcode.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+End-to-end check for transcode.py's background convert job (#50).
+
+`ConvertPlugin.convert_item`'s call shape changed completely between
+beets 2.11 and 2.13 (positional pipeline args vs. plugin.config-backed
+cached_property reads) — this actually runs a conversion end-to-end
+rather than just checking transcode.py imports cleanly, since the old
+signature would type-error and a wrong-but-importable fix could still
+silently write nothing.
+
+Run: python test_transcode.py
+Needs ffmpeg (with an mp3 encoder) to make and convert test audio.
+"""
+import json
+import shutil
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import test_importsession as ti
+
+DEST_FMT = 'mp3'
+
+
+def main():
+    if not shutil.which('ffmpeg'):
+        raise SystemExit('ffmpeg needed to generate test audio — skipping')
+
+    tmp = Path(tempfile.mkdtemp(prefix='beetsgui-convert-test-'))
+    beetsdir = tmp / 'beets'
+    beetsdir.mkdir()
+    plugindir = beetsdir / 'plugins'
+    plugindir.mkdir()
+    (plugindir / 'stubsource.py').write_text(ti.STUB_PLUGIN)
+    dest_dir = tmp / 'converted'
+    (beetsdir / 'config.yaml').write_text(
+        f'directory: {tmp / "library"}\n'
+        f'library: {beetsdir / "library.db"}\n'
+        f'pluginpath: [{plugindir}]\n'
+        f'plugins: [stubsource, convert]\n'
+        'import:\n'
+        '    resume: ask\n'
+        '    copy: yes\n'
+        '    write: no\n'
+        'convert:\n'
+        f'    dest: {dest_dir}\n'
+        f'    format: {DEST_FMT}\n'
+    )
+
+    src = tmp / 'incoming'
+    # FLAC source: DEST_FMT (mp3) differs from it, so should_transcode()
+    # is true and convert_item actually encodes rather than just copying.
+    ti.make_album(src / 'one', 'Convert Artist', 'Convert Album', ['Alpha'],
+                  ext='flac')
+
+    ti.job[0] = None
+    proc = ti.start_server(beetsdir)
+    try:
+        for event in ti.run(src / 'one'):
+            if event['type'] == 'decision':
+                ti.decide(event, choice='asis')
+        con = sqlite3.connect(beetsdir / 'library.db')
+        (path,) = con.execute(
+            "SELECT path FROM items WHERE artist = 'Convert Artist'").fetchone()
+        con.close()
+        assert path, 'import did not land the track'
+
+        status, body = ti.post('/convert/start', {
+            'query': 'artist:"Convert Artist"', 'pretend': False})
+        assert status == 200 and body['ok'], body
+        tail = list(ti.events(body['id']))
+        assert tail and tail[-1]['type'] == 'done' and not tail[-1].get('aborted'), tail
+
+        converted = list(dest_dir.rglob(f'*.{DEST_FMT}'))
+        assert converted, f'no .{DEST_FMT} file landed in {dest_dir}'
+        assert converted[0].stat().st_size > 0, 'converted file is empty'
+        print('ok')
+    finally:
+        ti.stop_server(proc)
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/transcode.py
+++ b/transcode.py
@@ -6,8 +6,14 @@ driven without its CLI wrapper.
 optparse namespace and has an interactive "Convert? (Y/n)" prompt baked
 in. The plugin's own auto-convert-on-import path (`auto_convert_keep`)
 shows the level below that — build a default opts namespace from the
-subcommand's parser, resolve it with `_get_opts_and_config`, and call
-`_parallel_convert` directly — so that's what this does.
+subcommand's parser and call `_parallel_convert` directly — so that's
+what this does.
+
+`_get_opts_and_config`/`convert_item`'s parameter list (beets < 2.13) vs.
+`self.config.set(vars(opts))` + `convert_item(keep_new)` reading
+dest/pretend/etc. off cached_property (beets >= 2.13) is a hard API
+break between the two — see #50. Detected by API shape, same as
+`importsession.py`'s AlbumMatch/DuplicateAction handling.
 
 Progress and abort come from a trick rather than a reimplementation:
 `_parallel_convert` builds `Pipeline([iter(items), ...])`, so passing a
@@ -54,20 +60,54 @@ def _feed(items, job):
         yield item
 
 
+# cached_property names convert_item's beets>=2.13 config reads pull from —
+# cleared before each job so a *previous* job's opts (format/dest/pretend)
+# don't leak into this one. The plugin instance is a module-level
+# singleton (`plugins._instances`), long-lived across jobs in this process,
+# unlike beets' own `beet convert` CLI which is a fresh process every time.
+_CACHED_CONFIG_ATTRS = (
+    'dest', 'threads', 'path_formats', 'fmt', 'playlist',
+    'pretend', 'force', 'refresh', 'hardlink', 'link', 'command',
+)
+
+
 def _run(job):
     lib = get_library()
     plugin = _plugin()
 
     opts = plugin.commands()[0].parser.get_default_values()
-    opts.format = job.meta.get('format') or None
+    # Leave format/dest at the parser default (already the config value)
+    # when not requested — beets >= 2.13 pushes `opts` straight into the
+    # plugin's config (see below), so an explicit None here would
+    # overwrite a real config value instead of falling back to it.
+    if job.meta.get('format'):
+        opts.format = job.meta['format']
     opts.pretend = bool(job.meta.get('pretend'))
     opts.album = False
     opts.yes = True                       # the UI's own confirm stands in
     if job.meta.get('dest'):
         opts.dest = job.meta['dest']
 
-    (dest, threads, path_formats, fmt, pretend, hardlink, link, _playlist,
-     force) = plugin._get_opts_and_config(opts)
+    if hasattr(plugin, '_get_opts_and_config'):
+        # beets < 2.13: opts resolved explicitly, passed to convert_item
+        # as positional pipeline-stage arguments.
+        (dest, threads, path_formats, fmt, pretend, hardlink, link,
+         _playlist, force) = plugin._get_opts_and_config(opts)
+        keep_new = opts.keep_new
+        make_stage = lambda: plugin.convert_item(         # noqa: E731
+            dest, keep_new, path_formats, fmt, pretend, link, hardlink, force)
+    else:
+        # beets >= 2.13 (#50): convert_item takes only (keep_new, item) and
+        # reads dest/pretend/etc. off the plugin's own config — the same
+        # mechanism beets' own convert_func uses.
+        for attr in _CACHED_CONFIG_ATTRS:
+            plugin.__dict__.pop(attr, None)
+        plugin.config.set(vars(opts))
+        dest, threads, path_formats, fmt, pretend = (
+            plugin.dest, plugin.threads, plugin.path_formats,
+            plugin.fmt, plugin.pretend)
+        keep_new = opts.keep_new
+        make_stage = lambda: plugin.convert_item(keep_new)  # noqa: E731
 
     items = list(lib.items(split_query(job.meta.get('query', ''))))
     if not items:
@@ -91,9 +131,7 @@ def _run(job):
     # Abort stops the source feeding, so anything already buffered still
     # gets encoded — with 16 in flight that made abort take minutes on
     # real audio (measured). At 1 it is bounded by the worker count.
-    stages = [plugin.convert_item(dest, opts.keep_new, path_formats, fmt,
-                                  pretend, link, hardlink, force)
-              for _ in range(threads)]
+    stages = [make_stage() for _ in range(threads)]
     pipeline.Pipeline([_feed(items, job), stages]).run_parallel(queue_size=1)
 
 


### PR DESCRIPTION
Closes #46, closes #47, closes #50.

#47 asked for a deliberate decision on which beets version to build against, not a blind `pip install --upgrade`. Researched by diffing beets' actual source, 2.11.0 vs 2.13.1 (both installed into throwaway venvs), plus checking `beets-beatport4`'s compatibility. Findings and recommendation posted on #47; this PR is the resulting fix.

## What was found

1. **#46's root cause.** `ImportSession.resolve_duplicate(task, found_duplicates)` — the abstract method `WebImportSession` overrode, mutating `task` directly — was replaced in 2.13 by `get_duplicate_action(task, found_duplicates) -> DuplicateAction`. The base class now ships a default implementation that just returns the config's `duplicate_action` (default `ask`) as a literal value; only `TerminalImportSession` overrides it again to actually prompt. Since `WebImportSession` still overrode the old, now-dead method, duplicates stopped reaching the browser entirely under 2.13 — not a beets detection regression.
2. **#50, found during the research, not previously known.** `beetsplug.convert`'s `convert_item` — which `transcode.py` calls directly, by its own design, because the plugin's public `convert_func` doesn't fit — was rewritten from a generator taking `(dest_dir, keep_new, path_formats, fmt, pretend, link, hardlink, force)` to a `@pipeline.mutator_stage` method taking only `(keep_new, item)`, reading `dest`/`pretend`/`link`/`hardlink`/`command` off `self` (`cached_property`s backed by the plugin's own `config`) instead of parameters. Fixing this also surfaced a latent bug in `transcode.py`'s own opts-building: passing `format=None` through to `self.config.set(vars(opts))` would have clobbered a real configured format with `None` — fixed by only setting `opts.format`/`opts.dest` when actually requested, which is correct under both beets versions.
3. Everything else checked (`mbsync`, `fetchart`, `embedart`'s private methods the app calls; `beets-beatport4`) is unaffected — see the #47 comment for detail.

## What changed

- `importsession.py`: `resolve_duplicate` (< 2.13) / `get_duplicate_action` (>= 2.13) now share one `_decide_duplicate` helper, selected at import time by whether `beets.importer.DuplicateAction` exists — same forward-compat pattern #45 used for `AlbumMatch`, not a version-number check.
- `transcode.py`: branches on `hasattr(plugin, '_get_opts_and_config')` to call `convert_item` in whichever shape the installed beets expects; clears the plugin's cached config properties before each job since the plugin instance is a long-lived singleton in this process (unlike beets' own CLI, which is a fresh process every run).
- `test_transcode.py` (new): the convert path had zero test coverage before this — it now runs an actual FLAC→MP3 conversion end-to-end through the HTTP job API and checks a non-empty file lands on disk. Importing cleanly isn't enough to catch this kind of break; only running it is.
- `test.yml`: pin moves to 2.13.1 (from 2.11.0), now runs both test files.
- `beets-canary.yml`: also runs `test_transcode.py`, for parity.

## Verified

- `test_importsession.py` and `test_transcode.py` both pass under beets 2.11.0, 2.13.1, and the actual local pipx install (`~/.local/pipx/venvs/beets`, still 2.11.0 — upgrading that is explicitly out of scope per #47, a separate deliberate action).

> **Model:** Sonnet · **Effort:** medium-high — cross-version source diffing plus writing new end-to-end coverage for a previously-untested path, not a mechanical signature swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
