### PR TITLE
Let a job queue behind an aborted-but-still-running one

### DIFF
--- a/.github/workflows/beets-canary.yml
+++ b/.github/workflows/beets-canary.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Run test_transcode.py
         run: python test_transcode.py
+
+      - name: Run test_jobs.py
+        run: python test_jobs.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Run test_transcode.py
         run: python test_transcode.py
+
+      - name: Run test_jobs.py
+        run: python test_jobs.py

--- a/beetsgui.html
+++ b/beetsgui.html
@@ -43,7 +43,8 @@
   html,body { height:100%; background:var(--bg); color:var(--text); font-family:var(--font-ui); font-weight:400; font-size:13px; line-height:1.6; }
   .app { display:flex; flex-direction:column; height:100vh; max-width:860px; margin:0 auto; }
   .app-header { display:flex; align-items:baseline; gap:0.75rem; padding:1rem 1.25rem 0; border-bottom:1px solid var(--border); flex-shrink:0; }
-  .prefs-btn { align-self:center; background:none; border:none; color:var(--text3); cursor:pointer; font-size:15px; margin-left:auto; padding:0.2rem 0.3rem; transition:color 0.1s; }
+  .job-queue-badge { align-self:center; margin-left:auto; font-size:11px; color:var(--text3); border:1px solid var(--border); border-radius:999px; padding:0.15rem 0.6rem; }
+  .prefs-btn { align-self:center; background:none; border:none; color:var(--text3); cursor:pointer; font-size:15px; margin-left:0.5rem; padding:0.2rem 0.3rem; transition:color 0.1s; }
   .prefs-btn:hover { color:var(--text2); }
   #prefs-dialog { background:var(--bg); border:1px solid var(--border); border-radius:var(--radius-lg); color:var(--text); margin:auto; max-height:85vh; padding:0; width:min(620px, 92vw); }
   #prefs-dialog::backdrop { background:rgba(0,0,0,0.55); }
@@ -182,6 +183,7 @@
   <div class="app-header">
     <span class="app-title" id="app-title"><span class="shadow" aria-hidden="true">BeetsGUI</span><span class="face">BeetsGUI</span></span>
     <span class="app-sub">beets music library assistant</span>
+    <span class="job-queue-badge" id="job-queue-badge" style="display:none"></span>
     <button class="prefs-btn" onclick="openPrefs()" title="Preferences (⌘,)">⚙</button>
   </div>
 
@@ -846,6 +848,31 @@ function checkCurrentImport(){
   }).catch(()=>{});
 }
 
+// A single "what's running" badge (#32) — covers import as well as the
+// generic job runner (sync/artwork/convert), since /jobs/current already
+// reports whichever kind is active. Self-stopping: only ticks while there's
+// something to show, rather than a permanent background timer (see the
+// Gnomon-shadow comment above for why this codebase avoids those by
+// default) — every job start/attach kicks it once so the badge appears
+// immediately rather than waiting up to one poll interval.
+let jobQueueTimer=null;
+function pollJobQueue(){
+  fetch('/jobs/current').then(r=>r.json()).then(data=>{
+    const badge=document.getElementById('job-queue-badge');
+    if(!badge)return;
+    if(!data.ok||!data.id){
+      badge.style.display='none';
+      if(jobQueueTimer){clearInterval(jobQueueTimer);jobQueueTimer=null;}
+      return;
+    }
+    let text=data.kind+(data.aborting?' aborting':' running');
+    if(data.queued)text+=' · '+data.queued.kind+' queued';
+    badge.textContent=text;
+    badge.style.display='inline-block';
+    if(!jobQueueTimer)jobQueueTimer=setInterval(pollJobQueue,2000);
+  }).catch(()=>{});
+}
+
 function attachImport(jobId){
   importState.jobId=jobId;importState.running=true;importState.decided=0;
   importState.log=[];importState.decision=null;
@@ -854,6 +881,7 @@ function attachImport(jobId){
   const es=new EventSource('/jobs/'+jobId+'/events');
   importState.es=es;
   es.onmessage=e=>handleImportEvent(JSON.parse(e.data));
+  pollJobQueue();
 }
 
 function handleImportEvent(ev){
@@ -1060,6 +1088,7 @@ function attachJob(id,el,onDone,queuedBehind){
   el.innerHTML='<div class="lib-count job-pulse" id="job-status">'+initial+'</div>'+
     '<div class="btn-row"><button class="btn btn-danger btn-sm" id="job-abort-btn" onclick="abortJob()">Abort</button></div>';
   jobRunner.es.onmessage=e=>handleJobEvent(JSON.parse(e.data));
+  pollJobQueue();
 }
 // mbsync/bpsync only checkpoint between phases, not between items within a
 // phase (see server.py's /jobs/<id>/abort docstring) — a click here can
@@ -1758,7 +1787,7 @@ function initGnomonShadow(){
   shadow.style.fontVariationSettings=`'TOTD' ${totd.toFixed(1)}, 'DIST' ${dist.toFixed(1)}`;
   face.style.fontVariationSettings=`'TOTD' ${totd.toFixed(1)}, 'DIST' 0`;
 }
-updatePathPreview();checkCurrentImport();loadModFields();checkFirstRun();initGnomonShadow();
+updatePathPreview();checkCurrentImport();pollJobQueue();loadModFields();checkFirstRun();initGnomonShadow();
 </script>
 </body>
 </html>

--- a/beetsgui.html
+++ b/beetsgui.html
@@ -1043,14 +1043,21 @@ function startJob(url,payload,elId,onDone){
     .then(r=>r.json())
     .then(data=>{
       if(!data.ok){el.innerHTML='<div class="alert alert-red">'+escapeHtml(data.error)+'</div>';return;}
-      attachJob(data.id,el,onDone);
+      attachJob(data.id,el,onDone,data.queued_behind);
     })
     .catch(()=>{el.innerHTML='<div class="lib-empty">Could not reach the server.</div>';});
 }
-function attachJob(id,el,onDone){
+// queuedBehind (#32): the server queued this job behind one still
+// finishing an abort instead of rejecting it — no real work has started
+// yet, so say that plainly rather than "Working…" until the first real
+// status event (once it actually starts) overwrites it.
+function attachJob(id,el,onDone,queuedBehind){
   if(jobRunner.es)jobRunner.es.close();
   jobRunner={es:new EventSource('/jobs/'+id+'/events'),id:id,el:el,onDone:onDone};
-  el.innerHTML='<div class="lib-count job-pulse" id="job-status">Working…</div>'+
+  const initial=queuedBehind
+    ?'Waiting for the current '+escapeHtml(queuedBehind)+' job to finish aborting…'
+    :'Working…';
+  el.innerHTML='<div class="lib-count job-pulse" id="job-status">'+initial+'</div>'+
     '<div class="btn-row"><button class="btn btn-danger btn-sm" id="job-abort-btn" onclick="abortJob()">Abort</button></div>';
   jobRunner.es.onmessage=e=>handleJobEvent(JSON.parse(e.data));
 }

--- a/jobs.py
+++ b/jobs.py
@@ -37,6 +37,10 @@ class Job:
         self.id = uuid.uuid4().hex
         self.kind = kind
         self.meta = meta
+        # Set by start() if this job was queued behind one still finishing
+        # an abort (#32) — the kind of the job it's waiting on, so the UI
+        # can say what's actually happening instead of a silent "Working…".
+        self.queued_behind = None
         # One queue per connected SSE stream, not one shared queue — two
         # tabs open on the same job each got a *subset* of events before
         # (both calling .get() on one queue splits the stream between them)
@@ -93,13 +97,19 @@ class Job:
 
     def summary(self):
         return {'id': self.id, 'kind': self.kind, 'aborting': self.aborted.is_set(),
-                **self.meta}
+                'queued_behind': self.queued_behind, **self.meta}
 
 
 # ── Registry ──────────────────────────────────────────────────────────────
 
 _jobs = {}
 _lock = threading.Lock()
+# At most one (job, work) queued behind a job that's still finishing an
+# abort (#32) — not a general queue. A second start() while one is already
+# queued still raises RuntimeError, same as while a job is running: the
+# invariant is "at most one beets job running or about to run," extended to
+# cover "about to run" rather than widened into an actual job queue.
+_pending = None
 
 
 def get(job_id):
@@ -118,28 +128,57 @@ def current():
 def start(job, work):
     """Register `job` and run `work(job)` on a background thread.
 
-    Raises RuntimeError if any job is still running. The 'done' event is
-    emitted from a finally block, so a client's stream always terminates
-    even when the work raises.
+    Raises RuntimeError if another job is running and hasn't been aborted.
+    If the running job *has* been aborted but beets gives it no way to stop
+    mid-unit (mbsync/bpsync — see sync.py), `job` is queued instead of
+    rejected: it starts automatically the instant that job's thread
+    actually exits, so the caller never has to poll and retry by hand. The
+    two jobs still never run concurrently — that's the mutation hazard the
+    registry exists to prevent (#29) — this only removes the manual retry.
+
+    The 'done' event is emitted from a finally block, so a client's stream
+    always terminates even when the work raises.
     """
+    global _pending
     with _lock:
         for existing in list(_jobs.values()):
             if existing.done.is_set():
                 del _jobs[existing.id]
-            else:
+                continue
+            if not existing.aborted.is_set() or _pending is not None:
                 raise RuntimeError(
                     f'another job is already running ({existing.kind})')
+            job.queued_behind = existing.kind
+            _jobs[job.id] = job
+            _pending = (job, work)
+            return job
         _jobs[job.id] = job
 
+    _launch(job, work)
+    return job
+
+
+def _launch(job, work):
     def run():
         try:
-            work(job)
+            if not job.aborted.is_set():
+                work(job)
         except Exception as e:
             job.emit('error', message=f'{type(e).__name__}: {e}')
         finally:
             job.emit('done', aborted=job.aborted.is_set(), **job.result)
             job.done.set()
+            _start_pending()
 
     job.thread = threading.Thread(target=run, daemon=True)
     job.thread.start()
-    return job
+
+
+def _start_pending():
+    """Launch the queued job, if any, now that its predecessor is done."""
+    global _pending
+    with _lock:
+        pending = _pending
+        _pending = None
+    if pending:
+        _launch(*pending)

--- a/jobs.py
+++ b/jobs.py
@@ -125,6 +125,14 @@ def current():
     return None
 
 
+def queued():
+    """The job waiting to start once `current()` actually finishes, if any —
+    so the UI can show both halves of a queued-behind-an-abort pair (#32),
+    not just whichever one it happens to be subscribed to."""
+    with _lock:
+        return _pending[0] if _pending else None
+
+
 def start(job, work):
     """Register `job` and run `work(job)` on a background thread.
 

--- a/server.py
+++ b/server.py
@@ -837,7 +837,11 @@ def job_abort(job_id):
     the beets plugin itself, with no hook to interrupt mid-loop without
     duplicating its matching logic. So this can legitimately time out with
     the job still running; `finished: false` is a true answer, not a bug,
-    and the caller is expected to say so rather than imply it's stuck."""
+    and the caller is expected to say so rather than imply it's stuck.
+
+    A still-running-but-aborted job no longer blocks the next one, though
+    (#32): starting a new job now queues it behind this one instead of
+    being rejected — see jobs.start()."""
     job = jobs.get(job_id)
     if not job:
         return jsonify({'ok': False, 'error': 'unknown job id'}), 404

--- a/server.py
+++ b/server.py
@@ -776,12 +776,18 @@ def sync_start():
 
 @app.route('/jobs/current')
 def jobs_current():
-    """The running job, if any — lets a reloaded page rejoin its stream."""
+    """The running job, if any — lets a reloaded page rejoin its stream.
+
+    Also reports the job queued behind it (#32), if any, so a client can
+    show both halves of a queued-behind-an-abort pair instead of just
+    whichever one it happens to be subscribed to."""
     job = jobs.current()
     if not job:
         return jsonify({'ok': True, 'id': None})
     decision = job.pending() if hasattr(job, 'pending') else None
-    return jsonify({'ok': True, **job.summary(), 'decision': decision})
+    queued = jobs.queued()
+    return jsonify({'ok': True, **job.summary(), 'decision': decision,
+                    'queued': queued.summary() if queued else None})
 
 
 @app.route('/jobs/<job_id>/events')

--- a/test_jobs.py
+++ b/test_jobs.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Unit test for jobs.py's queue-behind-an-abort behaviour (#32).
+
+mbsync/bpsync can't stop mid-phase (see sync.py), so aborting one leaves
+it running for real, sometimes for minutes. Before this fix that meant
+no other job could start until it finished on its own — the only escape
+was restarting the server. This checks the actual registry logic with
+synthetic slow jobs, no beets/Flask/ffmpeg needed.
+
+Run: python test_jobs.py
+"""
+import threading
+
+import jobs
+
+
+def make_slow_job(gate):
+    """A work(job) that blocks on `gate` then records that it ran."""
+    ran = threading.Event()
+
+    def work(job):
+        gate.wait(timeout=5)
+        ran.set()
+    return work, ran
+
+
+def main():
+    # 1. A job can't start while another is running and not aborted.
+    gate_a = threading.Event()
+    work_a, ran_a = make_slow_job(gate_a)
+    job_a = jobs.Job('sync-a')
+    jobs.start(job_a, work_a)
+    try:
+        jobs.start(jobs.Job('sync-b'), lambda j: None)
+        assert False, 'expected RuntimeError while a job is running'
+    except RuntimeError:
+        pass
+
+    # 2. Abort A (cooperative — like mbsync mid-phase, it keeps running).
+    #    A second job now queues instead of being rejected.
+    job_a.abort()
+    assert not job_a.done.is_set(), 'test setup: A should still be running'
+    gate_b = threading.Event()
+    work_b, ran_b = make_slow_job(gate_b)
+    job_b = jobs.Job('sync-b')
+    result = jobs.start(job_b, work_b)
+    assert result is job_b
+    assert job_b.queued_behind == 'sync-a', job_b.queued_behind
+    assert not ran_b.is_set(), 'B must not run while A is still finishing'
+
+    # 3. Only one job may queue behind it — a third is still rejected.
+    try:
+        jobs.start(jobs.Job('sync-c'), lambda j: None)
+        assert False, 'expected RuntimeError with one job already queued'
+    except RuntimeError:
+        pass
+
+    # 4. Once A actually finishes, B starts automatically — no manual retry,
+    #    no server restart.
+    gate_a.set()
+    assert job_a.done.wait(timeout=5), 'A should finish once its gate opens'
+    gate_b.set()
+    assert job_b.done.wait(timeout=5), 'B should auto-start once A finishes'
+    assert ran_b.is_set(), "B's work must actually have run"
+
+    # 5. Aborting a job while it's still queued (before its turn comes)
+    #    skips its work entirely instead of running it anyway.
+    gate_d = threading.Event()
+    work_d, ran_d = make_slow_job(gate_d)
+    job_d = jobs.Job('sync-d')
+    jobs.start(job_d, work_d)
+    job_d.abort()
+
+    gate_e = threading.Event()
+    work_e, ran_e = make_slow_job(gate_e)
+    job_e = jobs.Job('sync-e')
+    jobs.start(job_e, work_e)
+    assert job_e.queued_behind == 'sync-d', job_e.queued_behind
+    job_e.abort()            # abort the *queued* job before its turn comes
+
+    gate_d.set()              # let D finish, which should launch E
+    assert job_d.done.wait(timeout=5)
+    assert job_e.done.wait(timeout=5), 'E should still transition to done'
+    assert not ran_e.is_set(), \
+        'E was aborted before it started — its work must not run'
+
+    print('ok')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Closes #32.

PR #44 made abort *honest* for sync jobs (mbsync/bpsync can't stop mid-phase, so it made the wait truthful instead of silent) but deliberately left the harder half open: the registry still rejected any new job until the aborted one finished on its own — no way to force it, no way to start anything else meanwhile, only a server restart.

## Options weighed, and why this one

Reimplementing mbsync/beatport4's own matching logic to get true mid-loop cancellation was considered and rejected again — that's the exact forking-a-third-party-plugin cost the #47/#50 beets-version work just demonstrated firsthand, paid twice over here since it'd mean forking two plugins, not one. Subprocess isolation (the only way to truly hard-kill the call) was also ruled out: it would mean rebuilding the SSE fan-out (`jobs.py`) and the import decision handshake (`importsession.py`) as IPC for every job type, not a #32-shaped change.

Checked before committing to the cheaper option: both network clients already carry real request timeouts (beets' MusicBrainz session defaults to 10s, beatport4's client has its own `HTTP_TIMEOUT`), so a wedged job is bounded in wall-clock time rather than genuinely stuck forever. Draining is sufficient here, not just cheap.

## What changed

- `jobs.start()` now queues at most one job behind an aborted-but-still-running one instead of rejecting it — launched automatically the instant the aborted job's thread actually exits. A second job while one is already queued is still rejected (the invariant stays "at most one job running or about to run," not a general queue). A job aborted while still queued skips its work entirely once its turn comes, rather than running it and ignoring the abort.
- The job panel says plainly that it's waiting ("Waiting for the current mbsync job to finish aborting…") instead of a misleading "Working…" until real progress starts.
- A small header badge (`jobs.queued()` / `/jobs/current`'s new `queued` field) shows *both* halves of a queued pair — e.g. "mbsync aborting · bpsync queued" — since the waiting message alone only exists in the panel of the job that got queued; a different tab, or the same tab after navigating away, had no way to see anything was running. Self-stopping poll: it only ticks while there's something to show, clearing its own interval the instant nothing's running rather than running forever in the background.

## Verified

- `test_jobs.py` (new): synthetic slow jobs exercise the registry's queueing logic directly — reject-while-running, queue-while-aborting, reject-a-second-queue-attempt, auto-launch on completion, and skip-work-when-aborted-while-queued. No beets/Flask/ffmpeg needed.
- `/jobs/current`'s new `queued` field checked through Flask's actual test client against the real route (not just unit-tested in isolation).
- The header badge checked live in-browser against both shapes (running+queued, and nothing running) — renders, hides, and clears its own timer correctly.
- `test_importsession.py` and `test_transcode.py` still pass — the existing import/convert abort paths are unchanged.

> **Model:** Sonnet · **Effort:** medium — bounded fix, options already scoped in the issue and reaffirmed here against facts (the timeout check) rather than just recalled from the original discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
