### PR TITLE
Turn the queued-behind-an-abort slot into a real, orderable queue

### DIFF
--- a/beetsgui.html
+++ b/beetsgui.html
@@ -45,6 +45,12 @@
   .app-header { display:flex; align-items:baseline; gap:0.75rem; padding:1rem 1.25rem 0; border-bottom:1px solid var(--border); flex-shrink:0; }
   .job-queue-badge { align-self:center; margin-left:auto; font-size:11px; color:var(--text3); border:1px solid var(--border); border-radius:999px; padding:0.15rem 0.6rem; }
   .prefs-btn { align-self:center; background:none; border:none; color:var(--text3); cursor:pointer; font-size:15px; margin-left:0.5rem; padding:0.2rem 0.3rem; transition:color 0.1s; }
+  .job-queue-panel { padding:0.4rem 1.25rem; border-bottom:1px solid var(--border); font-size:11px; color:var(--text3); flex-shrink:0; }
+  .job-queue-row { display:flex; align-items:center; gap:0.4rem; padding:0.15rem 0; }
+  .job-queue-row .kind { flex:1; }
+  .job-queue-row button { background:none; border:1px solid var(--border); border-radius:4px; color:var(--text3); cursor:pointer; font-size:10px; line-height:1.4; padding:0 0.35rem; }
+  .job-queue-row button:disabled { cursor:default; opacity:0.3; }
+  .job-queue-row button:hover:not(:disabled) { color:var(--text2); }
   .prefs-btn:hover { color:var(--text2); }
   #prefs-dialog { background:var(--bg); border:1px solid var(--border); border-radius:var(--radius-lg); color:var(--text); margin:auto; max-height:85vh; padding:0; width:min(620px, 92vw); }
   #prefs-dialog::backdrop { background:rgba(0,0,0,0.55); }
@@ -186,6 +192,8 @@
     <span class="job-queue-badge" id="job-queue-badge" style="display:none"></span>
     <button class="prefs-btn" onclick="openPrefs()" title="Preferences (⌘,)">⚙</button>
   </div>
+
+  <div class="job-queue-panel" id="job-queue-panel" style="display:none"></div>
 
   <div class="tabs" role="tablist">
     <button class="tab-btn active" onclick="switchTab('inbox',this)">Inbox</button>
@@ -848,29 +856,54 @@ function checkCurrentImport(){
   }).catch(()=>{});
 }
 
-// A single "what's running" badge (#32) — covers import as well as the
-// generic job runner (sync/artwork/convert), since /jobs/current already
-// reports whichever kind is active. Self-stopping: only ticks while there's
-// something to show, rather than a permanent background timer (see the
-// Gnomon-shadow comment above for why this codebase avoids those by
-// default) — every job start/attach kicks it once so the badge appears
-// immediately rather than waiting up to one poll interval.
+// A single "what's running" badge plus the full wait line (#32) — covers
+// import as well as the generic job runner (sync/artwork/convert), since
+// /jobs/current already reports whichever kind is active. Self-stopping:
+// only ticks while there's something to show, rather than a permanent
+// background timer (see the Gnomon-shadow comment above for why this
+// codebase avoids those by default) — every job start/attach kicks it once
+// so the badge appears immediately rather than waiting up to one poll
+// interval.
 let jobQueueTimer=null;
 function pollJobQueue(){
   fetch('/jobs/current').then(r=>r.json()).then(data=>{
     const badge=document.getElementById('job-queue-badge');
-    if(!badge)return;
+    const panel=document.getElementById('job-queue-panel');
+    if(!badge||!panel)return;
     if(!data.ok||!data.id){
       badge.style.display='none';
+      panel.style.display='none';panel.innerHTML='';
       if(jobQueueTimer){clearInterval(jobQueueTimer);jobQueueTimer=null;}
       return;
     }
+    const queued=data.queued||[];
     let text=data.kind+(data.aborting?' aborting':' running');
-    if(data.queued)text+=' · '+data.queued.kind+' queued';
+    if(queued.length)text+=' · '+queued.length+' queued';
     badge.textContent=text;
     badge.style.display='inline-block';
+    if(queued.length){
+      panel.innerHTML=queued.map((q,i)=>
+        '<div class="job-queue-row">'+
+          '<span class="kind">'+(i+1)+'. '+escapeHtml(q.kind)+'</span>'+
+          '<button title="Move earlier"'+(i===0?' disabled':'')+
+            ' onclick="moveQueuedJob(\''+q.id+'\',\'up\')">↑</button>'+
+          '<button title="Move later"'+(i===queued.length-1?' disabled':'')+
+            ' onclick="moveQueuedJob(\''+q.id+'\',\'down\')">↓</button>'+
+          '<button title="Remove from queue" onclick="dequeueJob(\''+q.id+'\')">✕</button>'+
+        '</div>').join('');
+      panel.style.display='block';
+    } else {
+      panel.innerHTML='';panel.style.display='none';
+    }
     if(!jobQueueTimer)jobQueueTimer=setInterval(pollJobQueue,2000);
   }).catch(()=>{});
+}
+function moveQueuedJob(id,direction){
+  fetch('/jobs/'+id+'/move',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({direction:direction})}).then(pollJobQueue).catch(()=>{});
+}
+function dequeueJob(id){
+  fetch('/jobs/'+id+'/dequeue',{method:'POST'}).then(pollJobQueue).catch(()=>{});
 }
 
 function attachImport(jobId){

--- a/jobs.py
+++ b/jobs.py
@@ -104,12 +104,12 @@ class Job:
 
 _jobs = {}
 _lock = threading.Lock()
-# At most one (job, work) queued behind a job that's still finishing an
-# abort (#32) — not a general queue. A second start() while one is already
-# queued still raises RuntimeError, same as while a job is running: the
-# invariant is "at most one beets job running or about to run," extended to
-# cover "about to run" rather than widened into an actual job queue.
-_pending = None
+# Jobs queued behind one still finishing an abort (#32), in run order. Still
+# never more than one *running* at a time — that's the mutation hazard the
+# registry exists to prevent (#29) — this is only a waiting line for whoever
+# goes next, same as the queue a paused printer builds instead of rejecting
+# every job sent to it.
+_pending = []
 
 
 def get(job_id):
@@ -126,11 +126,35 @@ def current():
 
 
 def queued():
-    """The job waiting to start once `current()` actually finishes, if any —
-    so the UI can show both halves of a queued-behind-an-abort pair (#32),
-    not just whichever one it happens to be subscribed to."""
+    """Jobs waiting to start once `current()` finishes, in run order."""
     with _lock:
-        return _pending[0] if _pending else None
+        return [job for job, _ in _pending]
+
+
+def dequeue(job_id):
+    """Remove a job that's still waiting in line (not the running one —
+    that's what /abort is for). Returns True if it was actually queued."""
+    with _lock:
+        for i, (job, _) in enumerate(_pending):
+            if job.id == job_id:
+                del _pending[i]
+                _jobs.pop(job_id, None)
+                return True
+    return False
+
+
+def move_queued(job_id, delta):
+    """Move a queued job earlier (delta=-1) or later (delta=+1) in line.
+    Returns True if moved, False if not queued or already at that end."""
+    with _lock:
+        for i, (job, _) in enumerate(_pending):
+            if job.id == job_id:
+                j = i + delta
+                if 0 <= j < len(_pending):
+                    _pending[i], _pending[j] = _pending[j], _pending[i]
+                    return True
+                return False
+    return False
 
 
 def start(job, work):
@@ -139,26 +163,25 @@ def start(job, work):
     Raises RuntimeError if another job is running and hasn't been aborted.
     If the running job *has* been aborted but beets gives it no way to stop
     mid-unit (mbsync/bpsync — see sync.py), `job` is queued instead of
-    rejected: it starts automatically the instant that job's thread
-    actually exits, so the caller never has to poll and retry by hand. The
-    two jobs still never run concurrently — that's the mutation hazard the
-    registry exists to prevent (#29) — this only removes the manual retry.
+    rejected — behind any job already waiting — and starts automatically
+    the instant its turn comes, so the caller never has to poll and retry
+    by hand. Jobs still never run concurrently — see the `_pending` note
+    above — this only removes the manual retry.
 
     The 'done' event is emitted from a finally block, so a client's stream
     always terminates even when the work raises.
     """
-    global _pending
     with _lock:
         for existing in list(_jobs.values()):
             if existing.done.is_set():
                 del _jobs[existing.id]
                 continue
-            if not existing.aborted.is_set() or _pending is not None:
+            if not existing.aborted.is_set():
                 raise RuntimeError(
                     f'another job is already running ({existing.kind})')
             job.queued_behind = existing.kind
             _jobs[job.id] = job
-            _pending = (job, work)
+            _pending.append((job, work))
             return job
         _jobs[job.id] = job
 
@@ -183,10 +206,8 @@ def _launch(job, work):
 
 
 def _start_pending():
-    """Launch the queued job, if any, now that its predecessor is done."""
-    global _pending
+    """Launch the next queued job, if any, now that its predecessor is done."""
     with _lock:
-        pending = _pending
-        _pending = None
-    if pending:
-        _launch(*pending)
+        nxt = _pending.pop(0) if _pending else None
+    if nxt:
+        _launch(*nxt)

--- a/server.py
+++ b/server.py
@@ -778,16 +778,37 @@ def sync_start():
 def jobs_current():
     """The running job, if any — lets a reloaded page rejoin its stream.
 
-    Also reports the job queued behind it (#32), if any, so a client can
-    show both halves of a queued-behind-an-abort pair instead of just
-    whichever one it happens to be subscribed to."""
+    Also reports the jobs queued behind it (#32), in run order, so a
+    client can show the whole line instead of just whichever one it
+    happens to be subscribed to."""
     job = jobs.current()
     if not job:
         return jsonify({'ok': True, 'id': None})
     decision = job.pending() if hasattr(job, 'pending') else None
-    queued = jobs.queued()
     return jsonify({'ok': True, **job.summary(), 'decision': decision,
-                    'queued': queued.summary() if queued else None})
+                    'queued': [q.summary() for q in jobs.queued()]})
+
+
+@app.route('/jobs/<job_id>/dequeue', methods=['POST'])
+def job_dequeue(job_id):
+    """Remove a job still waiting in line (#32). The running job can't be
+    dequeued this way — that's what /abort is for."""
+    if jobs.dequeue(job_id):
+        return jsonify({'ok': True})
+    return jsonify({'ok': False, 'error': 'job is not queued'}), 404
+
+
+@app.route('/jobs/<job_id>/move', methods=['POST'])
+def job_move(job_id):
+    """Reorder a queued job (#32). Body: {"direction": "up"|"down"}."""
+    data = request.get_json(silent=True) or {}
+    delta = {'up': -1, 'down': 1}.get(data.get('direction'))
+    if delta is None:
+        return jsonify({'ok': False, 'error': 'direction must be "up" or "down"'}), 400
+    if jobs.move_queued(job_id, delta):
+        return jsonify({'ok': True})
+    return jsonify({'ok': False,
+                     'error': 'job is not queued, or already at that end'}), 404
 
 
 @app.route('/jobs/<job_id>/events')

--- a/test_jobs.py
+++ b/test_jobs.py
@@ -15,12 +15,15 @@ import threading
 import jobs
 
 
-def make_slow_job(gate):
-    """A work(job) that blocks on `gate` then records that it ran."""
+def make_slow_job(gate, run_order=None, label=None):
+    """A work(job) that blocks on `gate`, then records that it ran (and,
+    if given a shared list, its label — for checking run *order*)."""
     ran = threading.Event()
 
     def work(job):
         gate.wait(timeout=5)
+        if run_order is not None:
+            run_order.append(label)
         ran.set()
     return work, ran
 
@@ -49,20 +52,27 @@ def main():
     assert job_b.queued_behind == 'sync-a', job_b.queued_behind
     assert not ran_b.is_set(), 'B must not run while A is still finishing'
 
-    # 3. Only one job may queue behind it — a third is still rejected.
-    try:
-        jobs.start(jobs.Job('sync-c'), lambda j: None)
-        assert False, 'expected RuntimeError with one job already queued'
-    except RuntimeError:
-        pass
+    # 3. A *second* job can also queue behind the first — the queue has no
+    #    depth limit, only "one running at a time" is enforced.
+    gate_c = threading.Event()
+    work_c, ran_c = make_slow_job(gate_c)
+    job_c = jobs.Job('sync-c')
+    jobs.start(job_c, work_c)
+    assert jobs.queued() == [job_b, job_c], jobs.queued()
 
-    # 4. Once A actually finishes, B starts automatically — no manual retry,
-    #    no server restart.
+    # 4. Once A finishes, B starts automatically; once B finishes, C does —
+    #    in the order they queued, no manual retry, no server restart.
     gate_a.set()
     assert job_a.done.wait(timeout=5), 'A should finish once its gate opens'
     gate_b.set()
     assert job_b.done.wait(timeout=5), 'B should auto-start once A finishes'
     assert ran_b.is_set(), "B's work must actually have run"
+    # C is now running (launched the instant B finished), not queued.
+    assert jobs.current() is job_c, jobs.current()
+    assert jobs.queued() == [], jobs.queued()
+    gate_c.set()
+    assert job_c.done.wait(timeout=5), 'C should auto-start once B finishes'
+    assert ran_c.is_set(), "C's work must actually have run"
 
     # 5. Aborting a job while it's still queued (before its turn comes)
     #    skips its work entirely instead of running it anyway.
@@ -84,6 +94,74 @@ def main():
     assert job_e.done.wait(timeout=5), 'E should still transition to done'
     assert not ran_e.is_set(), \
         'E was aborted before it started — its work must not run'
+
+    # 6. A queued (not running) job can be removed from the line entirely —
+    #    it never runs, and whoever was behind it moves up.
+    gate_f = threading.Event()
+    work_f, ran_f = make_slow_job(gate_f)
+    job_f = jobs.Job('sync-f')
+    jobs.start(job_f, work_f)
+    job_f.abort()
+
+    gate_g = threading.Event()
+    work_g, ran_g = make_slow_job(gate_g)
+    job_g = jobs.Job('sync-g')
+    jobs.start(job_g, work_g)
+
+    gate_h = threading.Event()
+    work_h, ran_h = make_slow_job(gate_h)
+    job_h = jobs.Job('sync-h')
+    jobs.start(job_h, work_h)
+    assert jobs.queued() == [job_g, job_h]
+
+    assert jobs.dequeue(job_g.id) is True
+    assert jobs.queued() == [job_h], jobs.queued()
+    assert jobs.dequeue(job_f.id) is False, \
+        'the running job is not "queued" — /abort is what cancels it'
+    assert jobs.dequeue('no-such-id') is False
+
+    gate_f.set()               # let F finish — G was dequeued, so H is next
+    assert job_f.done.wait(timeout=5)
+    gate_h.set()
+    assert job_h.done.wait(timeout=5), 'H should auto-start once F finishes'
+    assert ran_h.is_set()
+    assert not ran_g.is_set(), 'G was dequeued — its work must never run'
+
+    # 7. A queued job's position can be changed, and the actual run order
+    #    reflects the new order, not the original queueing order.
+    run_order = []
+    gate_i = threading.Event()
+    work_i, _ = make_slow_job(gate_i)
+    job_i = jobs.Job('sync-i')
+    jobs.start(job_i, work_i)
+    job_i.abort()
+
+    gate_j = threading.Event()
+    work_j, _ = make_slow_job(gate_j, run_order, 'J')
+    job_j = jobs.Job('sync-j')
+    jobs.start(job_j, work_j)
+
+    gate_k = threading.Event()
+    work_k, _ = make_slow_job(gate_k, run_order, 'K')
+    job_k = jobs.Job('sync-k')
+    jobs.start(job_k, work_k)
+
+    gate_l = threading.Event()
+    work_l, _ = make_slow_job(gate_l, run_order, 'L')
+    job_l = jobs.Job('sync-l')
+    jobs.start(job_l, work_l)
+    assert jobs.queued() == [job_j, job_k, job_l]
+
+    assert jobs.move_queued(job_j.id, -1) is False, 'J is already at the front'
+    assert jobs.move_queued(job_l.id, +1) is False, 'L is already at the back'
+    assert jobs.move_queued(job_l.id, -1) is True   # [J, L, K]
+    assert jobs.queued() == [job_j, job_l, job_k], jobs.queued()
+
+    gate_i.set()
+    for gate in (gate_j, gate_l, gate_k):
+        gate.set()
+    assert job_k.done.wait(timeout=5), 'the last-run job should finish last'
+    assert run_order == ['J', 'L', 'K'], run_order
 
     print('ok')
 


### PR DESCRIPTION
Follow-up to the previous #32 PR, which capped the "queue behind an aborting job" slot at exactly one. Reasonable next question the owner raised: if you can queue one thing, why not several — with the ability to reorder or drop one before its turn comes?

## What changed

- `jobs.py`: `_pending` is now a list, not a single slot. `start()` appends to it instead of rejecting once one job is already waiting — no depth limit, only "one *running* at a time" is still enforced (that's the beets shared-state constraint, unchanged). New `jobs.dequeue(job_id)` removes a job that hasn't started yet; `jobs.move_queued(job_id, delta)` reorders it. Both leave the running job alone — cancelling that is still what `/abort` is for.
- `server.py`: `/jobs/current`'s `queued` field is now the full list, in run order. New `POST /jobs/<id>/dequeue` and `POST /jobs/<id>/move` (body `{"direction": "up"|"down"}`).
- `beetsgui.html`: the header badge now shows a count ("mbsync aborting · 3 queued"), and a panel below it lists every queued job with move-up/move-down/remove buttons (disabled at the ends).

## Sortable.js — considered, rejected

Asked directly whether to use it for drag-to-reorder. This app currently has **zero** third-party JS dependencies — one self-contained HTML file, no build step, no CDN script tags anywhere. Adding the first one, for a queue that's realistically a handful of items, didn't clear the bar: either vendor ~40KB of code with no package manager to update it, or pull from a CDN and lose the fully-offline/localhost-only character the app otherwise has. Plain buttons get the same reordering ability in a few lines, with no new dependency, no accessibility regression, and no touch-vs-mouse edge cases to chase.

## Verified

- `test_jobs.py` extended: multi-depth queueing (3 deep), auto-launch in order, dequeuing a specific job (and that a *running* job can't be dequeued), and reordering — checked by actual run order after the reorder, not just that `move_queued` returns `True`.
- The new HTTP routes checked through Flask's real test client (not just the unit-level registry functions) — current+queued shape, move, dequeue, dequeue-the-running-job (rejected), bad `direction` (400).
- Live in-browser: ran an actual server process with a real 3-job queue, clicked ✕ on a queued job and watched it disappear from a follow-up poll, clicked ↓ on the front item and watched the real reorder happen — not a mocked fetch.
- `test_importsession.py` and `test_transcode.py` still pass.

Found but not fixed here (flagged separately, task queued): `checkCurrentImport()` on page load attaches the *import* UI to whatever job `/jobs/current` returns without checking its kind — reloading during a running sync job wrongly shows "Import running". Pre-existing, unrelated to this change; surfaced while testing this one live.

> **Model:** Sonnet · **Effort:** medium — extends an already-scoped mechanism (list instead of one slot) rather than new design; the dependency question was the one real decision point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
