### PR TITLE
Fix: don't attach the import UI to a non-import job on reload

### DIFF
--- a/beetsgui.html
+++ b/beetsgui.html
@@ -849,8 +849,12 @@ function startImport(){
 }
 
 function checkCurrentImport(){
+  // Only reattach the import UI to an actual import — /jobs/current
+  // returns whichever kind is currently running, and a reload while a
+  // sync/artwork/convert job happens to be active must not show a fake
+  // "Import running" panel that no import event will ever update.
   fetch('/jobs/current').then(r=>r.json()).then(data=>{
-    if(!data.id)return;
+    if(!data.id||data.kind!=='import')return;
     attachImport(data.id);
     if(data.decision){importState.decision=data.decision;importState.selected=0;renderDecision();}
   }).catch(()=>{});


### PR DESCRIPTION
Pre-existing bug, unrelated to any of the recent beets-version or job-queue work — surfaced incidentally while live-testing the #32 job-queue PR against a real running sync job.

`checkCurrentImport()` (called once at page load) does:

```js
fetch('/jobs/current').then(r=>r.json()).then(data=>{
  if(!data.id)return;
  attachImport(data.id);
  ...
```

— it reattaches the import UI to *whatever* job `/jobs/current` reports, without checking `data.kind`. With a sync job (e.g. `mbsync`) running or aborting server-side, reloading the page showed "Import running / 0 decided so far — Working…" with a live Abort button, even though no import was running — that job's SSE stream never emits import-shaped events, so the panel just sits frozen.

Fix: guard the call on `data.kind === 'import'`. One line.

## Verified

- Live: a real server with a running/aborting `mbsync` job, reload — badge shows "mbsync aborting", no fake import panel.
- Live: a real `import`-kind job, reload — still reattaches correctly (unchanged behavior).
- `test_jobs.py`, `test_importsession.py`, `test_transcode.py` all still pass (this is a frontend-only change, no backend touched).

> **Model:** Sonnet · **Effort:** low — one-line guard, already root-caused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
