### PR TITLE
Recover most-played track list from old Traktor files (#42)

### DIFF
--- a/beetsgui.html
+++ b/beetsgui.html
@@ -199,6 +199,7 @@
     <button class="tab-btn active" onclick="switchTab('inbox',this)">Inbox</button>
     <button class="tab-btn" onclick="switchTab('library',this)">Library</button>
     <button class="tab-btn" onclick="switchTab('export',this)">Export</button>
+    <button class="tab-btn" onclick="switchTab('recover',this)">Recover</button>
   </div>
 
   <div class="content">
@@ -570,6 +571,48 @@
       </div>
     </div>
 
+    <!-- RECOVER (#42) -->
+    <div id="tab-recover" class="tab-panel">
+      <div class="section">
+        <div class="section-title">
+          <span>Most-played tracks from old Traktor files</span>
+          <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Reads old collection.nml, history .nml and .m3u files to rebuild what you played most, so you can go re-source what's still missing. Only ever reads them — nothing is moved, changed or deleted.</span></span>
+        </div>
+        <div class="field">
+          <label for="traktor-roots">Folders to search</label>
+          <input type="text" id="traktor-roots" placeholder="~/Documents" value="~/Documents">
+          <div class="drop-hint">Comma-separated. Add an external drive here later and re-scan — results build up rather than starting over.</div>
+        </div>
+        <div class="btn-row">
+          <button class="btn btn-primary" onclick="startTraktorScan(false)"><span>Scan</span></button>
+          <button class="btn" onclick="startTraktorScan(true)">Rebuild from scratch</button>
+        </div>
+        <div id="traktor-job"></div>
+      </div>
+      <div class="section">
+        <div class="section-title">
+          <span>Recovered tracks</span>
+          <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Play count is the highest number seen across all your snapshots, not a total — see the note under the list.</span></span>
+        </div>
+        <div class="btn-row">
+          <select id="traktor-sort" onchange="loadTraktor()">
+            <option value="play_count">Most played</option>
+            <option value="histories">Most played live (gig history)</option>
+            <option value="playlists">Most playlisted</option>
+            <option value="rating">Highest rated</option>
+          </select>
+          <label class="check-item"><input type="checkbox" id="traktor-missing" checked onchange="loadTraktor()"> Only tracks not in my library</label>
+          <button class="btn btn-sm" onclick="loadTraktor()">Refresh</button>
+        </div>
+        <div class="lib-results" id="traktor-results"></div>
+        <div id="traktor-assumptions"></div>
+        <details id="traktor-sources-box" style="display:none;margin-top:0.75rem;">
+          <summary>Source files</summary>
+          <div class="lib-results" id="traktor-sources"></div>
+        </details>
+      </div>
+    </div>
+
   <dialog id="prefs-dialog">
     <div class="prefs-header">
       <span class="prefs-title">Preferences</span>
@@ -763,6 +806,85 @@ function switchTab(name,btn){
   if(btn)btn.classList.add('active');
   activeTab=name;
   if(name==='library'){buildLibCmd();loadLibrary();}
+  if(name==='recover'){loadTraktor();}
+}
+
+// ── Recover: most-played tracks from old Traktor files (#42) ────────────────
+function startTraktorScan(reset){
+  const roots=document.getElementById('traktor-roots').value.split(',')
+    .map(s=>s.trim()).filter(Boolean);
+  if(reset&&!confirm('Discard the recovered list and rebuild it from the source files?'))return;
+  startJob('/traktor/scan/start',{roots:roots,reset:!!reset},'traktor-job',loadTraktor);
+}
+function loadTraktor(){
+  const results=document.getElementById('traktor-results');
+  const sort=document.getElementById('traktor-sort').value;
+  const missing=document.getElementById('traktor-missing').checked?'1':'0';
+  results.innerHTML='<div class="lib-empty">Loading…</div>';
+  fetch('/traktor/results?sort='+sort+'&missing_only='+missing+'&limit=300')
+    .then(r=>r.json())
+    .then(data=>{
+      if(!data.ok){results.innerHTML='<div class="alert alert-red">'+escapeHtml(data.error)+'</div>';return;}
+      if(!data.scanned){
+        results.innerHTML='<div class="lib-empty">Nothing scanned yet — hit Scan above.</div>';
+        document.getElementById('traktor-assumptions').innerHTML='';
+        return;
+      }
+      renderTraktor(data);
+    })
+    .catch(()=>{results.innerHTML='<div class="lib-empty">Could not reach the server.</div>';});
+}
+function renderTraktor(data){
+  const results=document.getElementById('traktor-results');
+  if(!data.tracks.length){
+    results.innerHTML='<div class="lib-empty">No tracks match — try unticking "only tracks not in my library".</div>';
+  }else{
+    results.innerHTML='<div class="lib-count">'+data.total+' track'+(data.total===1?'':'s')+
+      (data.tracks.length<data.total?' — showing first '+data.tracks.length:'')+'</div>'+
+      data.tracks.map(t=>{
+        // An unknown artist is shown as exactly that. Traktor never recorded
+        // one for a third of these entries, and inventing a plausible-looking
+        // artist would send the owner hunting for a record that doesn't exist.
+        const who=t.artist?escapeHtml(t.artist):'<span class="lib-row-meta">artist unknown</span>';
+        const bits=[];
+        if(t.play_count)bits.push('▶ '+t.play_count+'×');
+        if(t.histories)bits.push('🎧 '+t.histories+' gig'+(t.histories===1?'':'s'));
+        if(t.playlist_count)bits.push('☰ '+t.playlist_count+' playlist'+(t.playlist_count===1?'':'s'));
+        if(t.rating)bits.push('★'.repeat(t.rating));
+        if(t.last_played)bits.push('last '+escapeHtml(t.last_played));
+        if(t.snapshots)bits.push('in '+t.snapshots+' snapshot'+(t.snapshots===1?'':'s')+
+          (t.eras>1?' / '+t.eras+' installs':''));
+        // A title-only row could only be matched on title, which is a guess,
+        // not a confirmation — say which it is.
+        const inLib=t.library_match==='exact'
+          ?'<span class="badge badge-rec">in library</span>'
+          :(t.library_match==='title-only'
+            ?'<span class="badge">title matches library — verify</span>':'');
+        // min-width:0 lets the flex child actually shrink (so the title can
+        // ellipsis), and the meta line wraps instead of running off the row —
+        // .lib-row-meta is nowrap because everywhere else it's a short chip
+        // pinned right, which is not what it is here.
+        return '<div class="lib-row"><div style="min-width:0;flex:1;">'+
+          '<div class="lib-row-title">'+who+' — '+escapeHtml(t.title)+' '+inLib+'</div>'+
+          '<div class="lib-row-meta" style="white-space:normal;margin-top:0.15rem;">'+
+          bits.join(' · ')+'</div></div></div>';
+      }).join('');
+  }
+  document.getElementById('traktor-assumptions').innerHTML=
+    '<div class="alert alert-yellow" style="font-size:10px;margin-top:0.75rem;">'+
+    data.assumptions.map(a=>escapeHtml(a)).join('<br><br>')+'</div>';
+  const bad=(data.sources||[]).filter(s=>s.status!=='ok');
+  const box=document.getElementById('traktor-sources-box');
+  box.style.display='';
+  box.querySelector('summary').textContent=
+    'Source files — '+(data.stats.files_parsed||0)+' read'+
+    (bad.length?', '+bad.length+' skipped':'');
+  document.getElementById('traktor-sources').innerHTML=
+    (bad.length
+      ?bad.map(s=>'<div class="lib-row"><div><div class="lib-row-title">'+
+         escapeHtml(s.name)+'</div><div class="lib-row-meta">'+
+         escapeHtml(s.error||s.status)+'</div></div></div>').join('')
+      :'<div class="lib-empty">Every source file was read.</div>');
 }
 function openPrefs(){
   buildConfig();

--- a/server.py
+++ b/server.py
@@ -32,6 +32,7 @@ try:
     import jobs
     import libops
     import sync
+    import traktor
     import transcode
     from beets.ui import UserError
     from beets.util import displayable_path
@@ -788,6 +789,72 @@ def sync_start():
     except RuntimeError as e:
         return jsonify({'ok': False, 'error': str(e)}), 409
     return jsonify({'ok': True, **job.summary()})
+
+
+@app.route('/traktor/scan/start', methods=['POST'])
+def traktor_scan_start():
+    """Rebuild the most-played list from old Traktor files (#42). Body:
+    {"roots": ["~/Documents"], "reset": false}. Progress streams on
+    /jobs/<id>/events.
+
+    Read-only on the sources: the owner has lost this collection three
+    times, so nothing here opens a .nml for writing, moves it, or deletes
+    it. The only write is this app's own state file next to library.db.
+    """
+    data = request.get_json(silent=True) or {}
+    roots = data.get('roots') or ['~/Documents']
+    if not isinstance(roots, list) or not all(isinstance(r, str) for r in roots):
+        return jsonify({'ok': False, 'error': 'roots must be a list of paths'}), 400
+    roots = [os.path.expanduser(r.strip()) for r in roots if r.strip()]
+    missing = [r for r in roots if not os.path.isdir(r)]
+    if not roots or missing:
+        return jsonify({'ok': False,
+                        'error': f'no such directory: {missing[0]}' if missing
+                                 else 'no roots given'}), 400
+    db_path = get_library_db_path()
+    try:
+        job = traktor.start(roots, traktor.state_path(db_path),
+                            db_path=db_path if Path(db_path).exists() else None,
+                            reset=bool(data.get('reset')))
+    except RuntimeError as e:
+        return jsonify({'ok': False, 'error': str(e)}), 409
+    return jsonify({'ok': True, **job.summary()})
+
+
+@app.route('/traktor/results')
+def traktor_results():
+    """The recovered list. Query: sort, missing_only, limit, offset.
+
+    `assumptions` travels with the data on purpose — the play counts are
+    estimates, and the UI has to be able to say so next to the numbers.
+    """
+    try:
+        limit = min(int(request.args.get('limit', 200)), 2000)
+        offset = max(int(request.args.get('offset', 0)), 0)
+    except ValueError:
+        return jsonify({'ok': False,
+                        'error': 'limit and offset must be integers'}), 400
+    path = traktor.state_path(get_library_db_path())
+    if not Path(path).exists():
+        return jsonify({'ok': True, 'total': 0, 'tracks': [], 'scanned': False,
+                        'assumptions': [], 'sources': [], 'stats': {}})
+    state = traktor.load_state(path)
+    # Re-checked on every read rather than only at scan time: the point of the
+    # list is "what do I still need", and importing a recovered track is
+    # exactly what makes a row stale. Costs one query against a read-only
+    # connection, and nothing is written back.
+    db_path = get_library_db_path()
+    if Path(db_path).exists():
+        traktor.annotate_library(state['tracks'], db_path)
+    out = traktor.results(
+        state,
+        sort=request.args.get('sort', 'play_count'),
+        missing_only=request.args.get('missing_only', '1') != '0',
+        limit=limit, offset=offset)
+    return jsonify({'ok': True, 'scanned': True, **out,
+                    'stats': state.get('stats', {}),
+                    'assumptions': traktor.assumptions(state),
+                    'sources': traktor.source_report(state)})
 
 
 @app.route('/jobs/current')

--- a/test_traktor.py
+++ b/test_traktor.py
@@ -1,0 +1,345 @@
+"""
+Checks for the Traktor recovery merge (#42). Run: python test_traktor.py
+
+No beets, no Flask, no network — everything here works on NML written into a
+temp dir, so the rules that decide what the owner goes and re-buys are
+checkable in isolation.
+"""
+import os
+import shutil
+import tempfile
+
+import traktor
+
+
+def write_nml(path, entries, playlists=(), history=False):
+    """Minimal but structurally real NML — same element/attribute names the
+    owner's own files use."""
+    rows = []
+    for e in entries:
+        info = []
+        if e.get('play') is not None:
+            info.append(f'PLAYCOUNT="{e["play"]}"')
+        if e.get('last'):
+            info.append(f'LAST_PLAYED="{e["last"]}"')
+        if e.get('rank') is not None:
+            info.append(f'RANKING="{e["rank"]}"')
+        artist = f' ARTIST="{e["artist"]}"' if e.get('artist') else ''
+        rows.append(
+            f'<ENTRY{artist} TITLE="{e["title"]}">'
+            f'<LOCATION DIR="/:m/:" FILE="{e.get("file", e["title"] + ".mp3")}" '
+            f'VOLUME="V"/>'
+            f'<INFO {" ".join(info)}/></ENTRY>')
+    nodes = []
+    for name, files in playlists:
+        pk = ''.join(
+            f'<ENTRY><PRIMARYKEY TYPE="TRACK" KEY="V/:m/:{f}"/></ENTRY>'
+            for f in files)
+        nodes.append(
+            f'<NODE TYPE="PLAYLIST" NAME="{name}">'
+            f'<PLAYLIST ENTRIES="{len(files)}" '
+            f'TYPE="{"PROTOCOL" if history else "LIST"}">{pk}</PLAYLIST>'
+            f'</NODE>')
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<NML VERSION="19"><HEAD COMPANY="x" PROGRAM="Traktor"/>'
+            f'<COLLECTION ENTRIES="{len(entries)}">{"".join(rows)}</COLLECTION>'
+            f'<PLAYLISTS><NODE TYPE="FOLDER" NAME="$ROOT"><SUBNODES '
+            f'COUNT="{len(nodes)}">{"".join(nodes)}</SUBNODES></NODE>'
+            '</PLAYLISTS></NML>')
+
+
+def test_normalisation():
+    # Prefix shapes taken from the owner's real titles.
+    assert traktor.norm_title('6a - 105 - De Cierto Desierto') == 'de cierto desierto'
+    assert traktor.norm_title('100 bpm - Phantom') == 'phantom'
+    assert traktor.norm_title('01 Inner Divinity') == 'inner divinity'
+    assert traktor.norm_title('Dunya (Original Mix) [Deep Bali]') == 'dunya'
+    # A single-digit leading number is part of the title, not a track number.
+    assert traktor.norm_title('7 Nation Army') == '7 nation army'
+    # A named remix is a different record and must not be folded away.
+    assert traktor.norm_title('Natur (Satori Remix)') == 'natur satori remix'
+    # Danish/German accents must not split a track from its beets counterpart.
+    assert traktor.norm_title('Siebdrück') == traktor.norm_title('Siebdruck')
+
+
+def test_track_key_tiers():
+    known, is_known = traktor.track_key('Meg', 'Dunya')
+    assert is_known and known.startswith('A\x00')
+    unknown, is_known2 = traktor.track_key('', 'Dirty Relapse')
+    assert not is_known2 and unknown.startswith('T\x00')
+    assert known != unknown
+
+
+def test_unpadded_dates_compare_correctly():
+    # '2018/9/9' > '2018/10/13' as strings; the real order is the opposite.
+    assert traktor._date_sort_key('2018/10/13') > traktor._date_sort_key('2018/9/9')
+
+
+def test_max_playcount_across_snapshots():
+    """The core rule: an older snapshot holding a higher count must win.
+
+    This is the case a 'newest snapshot wins' merge would lose, and the one
+    the owner's three collection losses make likely.
+    """
+    tmp = tempfile.mkdtemp()
+    try:
+        old = os.path.join(tmp, 'Traktor 2.11.3', 'Backup', 'Collection')
+        new = os.path.join(tmp, 'Traktor 3.9.0', 'Backup', 'Collection')
+        os.makedirs(old)
+        os.makedirs(new)
+        write_nml(os.path.join(old, 'collection_2018y11m07d_02h35m35s.nml'),
+                  [{'artist': 'Mom', 'title': 'Black Sunrise', 'play': 35,
+                    'last': '2018/9/9', 'rank': 255}])
+        # Same track, rebuilt collection, play history gone.
+        write_nml(os.path.join(new, 'collection_2023y08m25d_14h48m17s.nml'),
+                  [{'artist': 'Mom', 'title': 'Black Sunrise', 'play': 0,
+                    'last': None, 'rank': 0}])
+        state = traktor.scan([tmp])
+        assert len(state['tracks']) == 1, state['tracks']
+        track = next(iter(state['tracks'].values()))
+        assert track['play_count'] == 35, track
+        assert track['rating'] == 255
+        assert track['snapshots'] == 2
+        assert len(track['eras']) == 2, 'each Traktor root is its own era'
+        assert '2018y11m07d' in track['play_count_source']
+    finally:
+        shutil.rmtree(tmp)
+
+
+def test_title_only_row_merges_into_full_row():
+    tmp = tempfile.mkdtemp()
+    try:
+        os.makedirs(os.path.join(tmp, 'Traktor 3.9.0'))
+        write_nml(os.path.join(tmp, 'Traktor 3.9.0', 'collection.nml'), [
+            {'artist': 'Discoshaman', 'title': 'Making A Cyborg Edit',
+             'play': 2, 'file': 'a.mp3'},
+            # Same record, artist folded into the title by Traktor.
+            {'artist': '', 'title': 'Discoshaman - Making A Cyborg Edit',
+             'play': 9, 'file': 'b.mp3'},
+            # Genuinely artist-less and unrecoverable — must stay separate.
+            {'artist': '', 'title': 'Dirty Relapse', 'play': 4, 'file': 'c.mp3'},
+        ])
+        state = traktor.scan([tmp])
+        by_title = {t['title']: t for t in state['tracks'].values()}
+        assert len(state['tracks']) == 2, by_title
+        merged = by_title['Making A Cyborg Edit']
+        assert merged['artist_known'] and merged['play_count'] == 9
+        assert not by_title['Dirty Relapse']['artist_known']
+    finally:
+        shutil.rmtree(tmp)
+
+
+def test_playlist_and_history_membership():
+    tmp = tempfile.mkdtemp()
+    try:
+        root = os.path.join(tmp, 'Traktor 3.9.0')
+        os.makedirs(os.path.join(root, 'History'))
+        write_nml(os.path.join(root, 'collection.nml'),
+                  [{'artist': 'Meg', 'title': 'Dunya', 'play': 1,
+                    'file': 'dunya.mp3'}],
+                  playlists=[('all23', ['dunya.mp3']),
+                             ('gig', ['dunya.mp3']),
+                             ('ghost', ['missing.mp3'])])
+        write_nml(os.path.join(root, 'History', 'history_2023y08m27d.nml'),
+                  [{'artist': '', 'title': 'Meg - Dunya', 'play': 1}],
+                  playlists=[('HISTORY', ['dunya.mp3'])], history=True)
+        # An .m3u carries paths only, so it must resolve via the basename index.
+        with open(os.path.join(tmp, 'set.m3u'), 'w', encoding='utf-8') as f:
+            f.write('# comment\n/Music/whatever/dunya.mp3\n')
+
+        state = traktor.scan([tmp])
+        track = next(t for t in state['tracks'].values()
+                     if t['title'] == 'Dunya')
+        assert track['playlists'] == {'all23', 'gig', 'set.m3u (m3u)'}, track['playlists']
+        assert track['histories'] == {'history_2023y08m27d.nml'}, track['histories']
+        # A history file is one gig, not a census — it must not inflate this.
+        assert track['snapshots'] == 1, track['snapshots']
+        # The reference to a file no snapshot knows is reported, not guessed.
+        assert state['stats']['unresolved_path_refs'] >= 1
+    finally:
+        shutil.rmtree(tmp)
+
+
+def test_ambiguous_basename_resolves_to_nothing():
+    tmp = tempfile.mkdtemp()
+    try:
+        os.makedirs(os.path.join(tmp, 'Traktor 3.9.0'))
+        write_nml(os.path.join(tmp, 'Traktor 3.9.0', 'collection.nml'), [
+            {'artist': 'A', 'title': 'One', 'file': 'dupe.mp3'},
+            {'artist': 'B', 'title': 'Two', 'file': 'dupe.mp3'},
+        ], playlists=[('mix', ['dupe.mp3'])])
+        state = traktor.scan([tmp])
+        assert state['basename_index']['dupe.mp3'] is None
+        for track in state['tracks'].values():
+            assert track['playlists'] == set(), 'must not guess between the two'
+        assert state['stats']['unresolved_path_refs'] == 1
+    finally:
+        shutil.rmtree(tmp)
+
+
+def test_bad_files_are_reported_never_dropped():
+    tmp = tempfile.mkdtemp()
+    try:
+        os.makedirs(os.path.join(tmp, 'Traktor 4.5.0'))
+        open(os.path.join(tmp, 'Traktor 4.5.0', 'empty.nml'), 'w').close()
+        with open(os.path.join(tmp, 'Traktor 4.5.0', 'broken.nml'), 'w') as f:
+            f.write('<NML><COLLECTION>truncated')
+        write_nml(os.path.join(tmp, 'Traktor 4.5.0', 'collection.nml'),
+                  [{'artist': 'A', 'title': 'Fine', 'play': 1}])
+
+        state = traktor.scan([tmp])
+        report = {r['name']: r for r in traktor.source_report(state)}
+        assert len(report) == 3, report
+        assert report['empty.nml']['status'] == 'skipped'
+        assert '0 bytes' in report['empty.nml']['error']
+        assert report['broken.nml']['status'] == 'failed'
+        assert 'malformed XML' in report['broken.nml']['error']
+        assert report['collection.nml']['status'] == 'ok'
+        assert state['stats']['files_parsed'] == 1
+        assert state['stats']['files_skipped'] == 2
+    finally:
+        shutil.rmtree(tmp)
+
+
+def test_icloud_placeholder_is_skipped_not_waited_on():
+    """A placeholder must never be opened during a scan.
+
+    Reading one blocks until iCloud delivers it, and `os.stat` blocks the
+    same way once a download has been requested — which is why there is no
+    timeout to test here, only a skip.
+    """
+    tmp = tempfile.mkdtemp()
+    real_is_dataless, real_request = traktor.is_dataless, traktor.request_download
+    requested = []
+    try:
+        os.makedirs(os.path.join(tmp, 'Traktor 3.11.1'))
+        evicted = os.path.join(tmp, 'Traktor 3.11.1', 'collection.nml')
+        write_nml(evicted, [{'artist': 'Meg', 'title': 'Dunya', 'play': 9}])
+        traktor.is_dataless = lambda st: True
+        traktor.request_download = lambda p: requested.append(p)
+
+        state = traktor.scan([tmp])
+        report = traktor.source_report(state)
+        assert report[0]['status'] == 'skipped'
+        assert 'not downloaded' in report[0]['error']
+        assert requested == [evicted], 'the download must still be started'
+        assert state['tracks'] == {}
+
+        # Once iCloud delivers it, the next scan picks it up — the file was
+        # never marked done, so incremental mode still has it on the list.
+        traktor.is_dataless = real_is_dataless
+        state = traktor.scan([tmp], state)
+        assert state['stats']['files_parsed'] == 1
+        assert next(iter(state['tracks'].values()))['play_count'] == 9
+    finally:
+        traktor.is_dataless, traktor.request_download = real_is_dataless, real_request
+        shutil.rmtree(tmp)
+
+
+def test_rescan_is_incremental_and_does_not_double_count():
+    """Re-running must not inflate 'seen in N snapshots' — that number is how
+    the owner judges how much corroboration a play count has."""
+    tmp = tempfile.mkdtemp()
+    try:
+        root = os.path.join(tmp, 'Traktor 3.9.0')
+        os.makedirs(root)
+        write_nml(os.path.join(root, 'collection.nml'),
+                  [{'artist': 'Meg', 'title': 'Dunya', 'play': 3}])
+        state = traktor.scan([tmp])
+        assert state['stats']['files_parsed'] == 1
+        first = next(iter(state['tracks'].values()))['snapshots']
+
+        state = traktor.scan([tmp], state)
+        assert state['stats']['files_read_this_run'] == 0, 'unchanged file re-parsed'
+        # The headline count describes the whole list, not just this run.
+        assert state['stats']['files_parsed'] == 1
+        assert next(iter(state['tracks'].values()))['snapshots'] == first
+
+        # Caveats shown to the owner must not reset just because a re-scan
+        # happened to read nothing.
+        merged_before = state['stats']['title_only_merged']
+        assert traktor.scan([tmp], state)['stats']['title_only_merged'] \
+            == merged_before
+
+        # A newly discovered source adds on top rather than rebuilding.
+        write_nml(os.path.join(root, 'collection_2024y01m01d.nml'),
+                  [{'artist': 'Meg', 'title': 'Dunya', 'play': 11}])
+        state = traktor.scan([tmp], state)
+        track = next(iter(state['tracks'].values()))
+        assert state['stats']['files_read_this_run'] == 1, 'only the new file'
+        assert state['stats']['files_parsed'] == 2, 'both now in the list'
+        assert track['play_count'] == 11 and track['snapshots'] == first + 1
+    finally:
+        shutil.rmtree(tmp)
+
+
+def test_library_match_marks_what_is_already_back():
+    """The whole point of the list is 'what do I still need', so a track
+    already back in beets must be distinguishable — and a title-only row
+    must never be presented as a confirmed hit."""
+    import sqlite3
+    tmp = tempfile.mkdtemp()
+    try:
+        db = os.path.join(tmp, 'library.db')
+        con = sqlite3.connect(db)
+        con.execute('CREATE TABLE items (artist TEXT, title TEXT)')
+        con.executemany('INSERT INTO items VALUES (?,?)', [
+            ('Meg', 'Dunya'),               # exact
+            ('Laroz', 'Miombo'),            # differs only by decoration
+            ('Someone', 'Dirty Relapse'),   # only the title can match
+        ])
+        con.commit()
+        con.close()
+
+        os.makedirs(os.path.join(tmp, 'Traktor 3.9.0'))
+        write_nml(os.path.join(tmp, 'Traktor 3.9.0', 'collection.nml'), [
+            {'artist': 'Meg', 'title': 'Dunya', 'play': 5},
+            {'artist': 'Laroz', 'title': '05 Miombo (Original Mix)', 'play': 3},
+            {'artist': 'Depart', 'title': 'Madman', 'play': 9},
+            {'artist': '', 'title': 'Dirty Relapse', 'play': 4},
+        ])
+        state = traktor.scan([tmp])
+        traktor.annotate_library(state['tracks'], db)
+        by_title = {t['title']: t for t in state['tracks'].values()}
+        assert by_title['Dunya']['library_match'] == 'exact'
+        assert by_title['05 Miombo (Original Mix)']['library_match'] == 'exact'
+        assert by_title['Madman']['library_match'] is None
+        # Artist unknown on our side — a title hit is a lead, not a match.
+        assert by_title['Dirty Relapse']['library_match'] == 'title-only'
+
+        shopping = traktor.results(state, missing_only=True)
+        assert [t['title'] for t in shopping['tracks']] == ['Madman'], shopping
+    finally:
+        shutil.rmtree(tmp)
+
+
+def test_state_round_trip():
+    tmp = tempfile.mkdtemp()
+    try:
+        os.makedirs(os.path.join(tmp, 'Traktor 3.9.0'))
+        write_nml(os.path.join(tmp, 'Traktor 3.9.0', 'collection.nml'),
+                  [{'artist': 'Meg', 'title': 'Dunya', 'play': 3}],
+                  playlists=[('gig', ['Dunya.mp3'])])
+        path = os.path.join(tmp, 'state.json')
+        traktor.save_state(traktor.scan([tmp]), path)
+        state = traktor.load_state(path)
+        track = next(iter(state['tracks'].values()))
+        assert isinstance(track['playlists'], set), 'sets must survive JSON'
+        assert track['playlists'] == {'gig'}
+        # And the reloaded state still skips work it already did.
+        assert traktor.scan([tmp], state)['stats']['files_read_this_run'] == 0
+    finally:
+        shutil.rmtree(tmp)
+
+
+def main():
+    for name, fn in sorted(globals().items()):
+        if name.startswith('test_') and callable(fn):
+            fn()
+    print('ok')
+
+
+if __name__ == '__main__':
+    main()

--- a/traktor.py
+++ b/traktor.py
@@ -1,0 +1,672 @@
+"""
+Recover a most-played / most-curated track list from old Traktor files (#42).
+
+The owner lost their collection three times. What survived is metadata:
+generations of Traktor `collection.nml`, per-gig `history_*.nml`, and `.m3u`
+playlists. This turns those into a ranked, deduplicated re-acquisition list.
+
+Three things about the real data drive the whole design:
+
+**Play count can only ever be estimated, so it is labelled as an estimate.**
+`INFO/@PLAYCOUNT` is real and confirmed. What is *not* documented anywhere by
+Native Instruments — not the manual, not the support articles — is whether a
+rebuilt collection keeps or resets it. The owner's own files can't settle it
+either: the losses contaminate the evidence. So the merge rule is chosen to be
+correct under *either* answer: **max across snapshots**. If backups accumulate,
+the newest snapshot already holds the max; if a rebuild resets to zero, an
+older snapshot still holds the real number. Summing would double-count, because
+every backup is a full snapshot of the collection (that part *is* documented),
+not a delta. Max can only ever under-report, never inflate — the honest
+direction for a shopping list. `assumptions()` states this in the UI.
+
+**A third of all entries have no ARTIST at all.** Measured: 1952/5983 (2018)
+and 1543/4634 (2023). 80% of those fold the artist into TITLE, but in mutually
+contradictory shapes — `'Discoshaman - Making A Cyborg Edit'` is artist-title
+while `"U Can't Slow This - Mc Hammer"` is title-artist, and
+`'Sydka - Sydka - Dark Hill Ep - 02 Sydka - Eclipse'` is neither. Guessing a
+split would invent wrong artists, and a wrong artist sends the owner hunting
+for a track that does not exist — worse than admitting we don't know. So rows
+keep two tiers: `artist_known` rows key on (artist, title); the rest key on
+title alone and are flagged, never silently presented as equals.
+
+**Playlists and histories reference tracks by path, which doesn't survive a
+reinstall.** So they resolve through a basename index built from the same
+collection snapshots — the same reason `/unimported` matches on (artist, title)
+rather than path. Basenames collide for 24 of 4634 files (0.5%); collisions
+resolve to nothing and are counted, never guessed.
+"""
+import json
+import os
+import re
+import subprocess
+import unicodedata
+import xml.etree.ElementTree as ET
+
+import jobs
+
+STATE_VERSION = 1
+
+# Extensions worth opening. `.m3u8` is the same format, UTF-8 by definition.
+_SUFFIXES = ('.nml', '.m3u', '.m3u8')
+
+
+# ── Normalisation ─────────────────────────────────────────────────────────
+
+# Each rule below earns its place from a shape actually present in the
+# owner's files; nothing here is speculative tidying.
+_PREFIX_RES = (
+    # '100 bpm - Arteriam & Wartemal feat. ... - Phantom FINAL PREMASTER'
+    re.compile(r'^\d{1,3}\s*bpm\s*-\s*', re.I),
+    # '6a - 105 - de cierto desierto' — 180 of these in the 2018 collection,
+    # a DJ-prep convention that was later dropped (1 hit in 2023).
+    re.compile(r'^\d{1,2}[adm]\s*-\s*\d{2,3}\s*-\s*', re.I),
+    # '01 Inner Divinity', '10 Bistro Riots' — leading track number.
+    # ponytail: two digits required, so '7 Nation Army' and '2 Bad' keep
+    # their real titles. A single-digit track number stays unstripped;
+    # that costs a few missed merges and risks no wrong ones.
+    re.compile(r'^\d{2}\s+(?=\S)'),
+)
+# 'Meg - Dunya (Original Mix) [Deep Bali Records]' — trailing label.
+_LABEL_RE = re.compile(r'\s*\[[^\]]*\]\s*$')
+# A no-op qualifier: '(Original Mix)' names no remixer, so it must not split
+# a track from itself. Every *other* parenthetical is kept — '(Satori Remix)'
+# is a different record and merging it would be a real error.
+_ORIGINAL_RE = re.compile(r'\s*\((?:original(?:\s+mix)?)\)\s*$', re.I)
+_NONALNUM_RE = re.compile(r'[^a-z0-9]+')
+
+
+def _fold(s):
+    """Case/accent/punctuation-insensitive form. NFKD because the collection
+    is Danish and German — 'siebdrück', 'Brombär', 'luçïd' must match their
+    beets counterparts however either side happened to encode them."""
+    s = unicodedata.normalize('NFKD', s or '')
+    s = ''.join(c for c in s if not unicodedata.combining(c))
+    return s.lower().strip()
+
+
+def norm_title(title):
+    t = _fold(title)
+    for _ in range(3):          # prefixes stack: '100 bpm - 6a - 105 - x'
+        before = t
+        for rx in _PREFIX_RES:
+            t = rx.sub('', t)
+        t = _LABEL_RE.sub('', t)
+        t = _ORIGINAL_RE.sub('', t)
+        if t == before:
+            break
+    return _NONALNUM_RE.sub(' ', t).strip()
+
+
+def norm_artist(artist):
+    return _NONALNUM_RE.sub(' ', _fold(artist)).strip()
+
+
+def collapse(s):
+    """Separator-free form, for linking a title-only row to a full one."""
+    return _NONALNUM_RE.sub('', _fold(s))
+
+
+def track_key(artist, title):
+    """Identity for a track. Returns (key, artist_known).
+
+    Two namespaces that can never collide: a row whose artist Traktor
+    actually recorded is not the same claim as a row where we only have a
+    title, and the UI has to be able to tell them apart.
+    """
+    nt = norm_title(title)
+    na = norm_artist(artist)
+    if na and nt:
+        return f'A\x00{na}\x00{nt}', True
+    return f'T\x00{nt or collapse(title)}', False
+
+
+# ── iCloud ────────────────────────────────────────────────────────────────
+
+def is_dataless(st):
+    """True for an iCloud placeholder: a real size with no blocks on disk."""
+    return st.st_blocks == 0 and st.st_size > 0
+
+
+def request_download(path):
+    """Ask iCloud for a placeholder's bytes and return immediately.
+
+    Deliberately fire-and-forget. Waiting here looks obvious and is a trap:
+    once a download has been requested, `os.stat` on that file *itself*
+    blocks until the fetch completes, so a poll loop with a deadline never
+    gets to check its deadline — measured on the owner's files, where six
+    of them stalled a scan indefinitely rather than for the intended 20s.
+    A blocking read has the same problem.
+
+    So a placeholder is skipped this run and reported as such, with its
+    download started in the background. Scans are incremental, so the next
+    one picks it up once iCloud has delivered it — no waiting, no threads to
+    abandon, and nothing silently dropped.
+    """
+    try:
+        subprocess.Popen(['brctl', 'download', path],
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except OSError:
+        pass
+
+
+# ── Source discovery and classification ───────────────────────────────────
+
+def find_sources(roots):
+    """Every .nml/.m3u under `roots`. stdlib walk, so no `fd` dependency for
+    a core feature (the README only requires fd for the Inbox utilities)."""
+    found = []
+    for root in roots:
+        root = os.path.expanduser(root)
+        for dirpath, _dirnames, filenames in os.walk(root):
+            for name in filenames:
+                if name.lower().endswith(_SUFFIXES):
+                    found.append(os.path.join(dirpath, name))
+    return sorted(set(found))
+
+
+def classify(path):
+    low = path.lower()
+    base = os.path.basename(low)
+    if base.endswith(('.m3u', '.m3u8')):
+        return 'm3u'
+    if '/history/' in low or base.startswith('history'):
+        return 'history'
+    if '/backup/collection/' in low:
+        return 'collection'
+    if base == 'collection.nml':
+        return 'collection'
+    return 'collection'
+
+
+def era_of(path):
+    """The Traktor root directory a file belongs to.
+
+    Native Instruments documents that every update gets its own root
+    directory named for its version, so that directory *is* the generation
+    boundary. Keyed on the full path, not just the version number, because
+    the owner turned out to have two independent installations synced into
+    iCloud (a second Mac) sharing version numbers — and a future external
+    drive would make a third.
+    """
+    m = re.search(r'^(.*/Traktor \d[\d.]*)/', path)
+    return m.group(1) if m else os.path.dirname(path)
+
+
+# ── Parsing ───────────────────────────────────────────────────────────────
+
+def _entry_records(collection_el):
+    """(key, artist_known, fields, basename) per ENTRY."""
+    out = []
+    for e in collection_el:
+        artist = (e.get('ARTIST') or '').strip()
+        title = (e.get('TITLE') or '').strip()
+        if not title:
+            continue
+        info = e.find('INFO')
+        loc = e.find('LOCATION')
+        key, known = track_key(artist, title)
+        try:
+            play = int((info.get('PLAYCOUNT') if info is not None else 0) or 0)
+        except (TypeError, ValueError):
+            play = 0
+        try:
+            rank = int((info.get('RANKING') if info is not None else 0) or 0)
+        except (TypeError, ValueError):
+            rank = 0
+        out.append({
+            'key': key,
+            'artist_known': known,
+            'artist': artist,
+            'title': title,
+            'play_count': play,
+            'rating': rank,
+            'last_played': (info.get('LAST_PLAYED') if info is not None else None),
+            'basename': ((loc.get('FILE') or '').lower()
+                         if loc is not None else ''),
+        })
+    return out
+
+
+def _playlist_nodes(playlists_el):
+    """(name, [primarykey, ...]) for every real playlist node.
+
+    SMARTLIST nodes are skipped: they are saved queries ('$PLAYED == TRUE'),
+    not curation — their membership is computed at display time and says
+    nothing about what the owner chose to put together.
+    """
+    out = []
+    if playlists_el is None:
+        return out
+    for node in playlists_el.iter('NODE'):
+        if node.get('TYPE') not in ('PLAYLIST',):
+            continue
+        pl = node.find('PLAYLIST')
+        if pl is None:
+            continue
+        keys = [pk.get('KEY') for pk in pl.iter('PRIMARYKEY') if pk.get('KEY')]
+        out.append((node.get('NAME') or '?', keys))
+    return out
+
+
+def parse_nml(path):
+    """{'entries': [...], 'playlists': [(name, [pathkey,...]), ...]}"""
+    root = ET.parse(path).getroot()
+    coll = root.find('COLLECTION')
+    return {
+        'entries': _entry_records(coll) if coll is not None else [],
+        'playlists': _playlist_nodes(root.find('PLAYLISTS')),
+    }
+
+
+def parse_m3u(path):
+    """Path lines only — .m3u carries no artist/title, so these resolve
+    through the basename index like any other path reference."""
+    with open(path, 'r', encoding='utf-8', errors='replace') as f:
+        return [l.strip() for l in f
+                if l.strip() and not l.strip().startswith('#')]
+
+
+def path_basename(primarykey_or_path):
+    """Last path component of either a Traktor PRIMARYKEY
+    ('VOLUME/:Users/:vsm/:Music/:x.mp3') or a plain .m3u line."""
+    s = (primarykey_or_path or '').replace('/:', '/')
+    return os.path.basename(s).lower()
+
+
+# ── Merge ─────────────────────────────────────────────────────────────────
+
+def _date_sort_key(d):
+    """'2018/10/13' sorts *before* '2018/9/9' as a string — Traktor writes
+    unpadded month/day, so comparing these lexically silently picks the
+    wrong 'most recent'. Parse instead."""
+    if not d:
+        return ()
+    try:
+        return tuple(int(p) for p in str(d).split('/'))
+    except ValueError:
+        return ()
+
+
+def _new_track(rec):
+    return {
+        'artist': rec['artist'],
+        'title': rec['title'],
+        'artist_known': rec['artist_known'],
+        'play_count': 0,
+        'play_count_source': None,
+        'rating': 0,
+        'last_played': None,
+        'snapshots': 0,
+        'eras': set(),
+        'playlists': set(),
+        'histories': set(),
+    }
+
+
+def _absorb_entry(track, rec, source, era, count_snapshot=True):
+    """Fold one snapshot's view of a track into the running aggregate.
+
+    `count_snapshot` is False for history files: they are a record of one
+    gig, not a census of the collection, so counting them would inflate
+    "seen in N snapshots" — the number the owner reads as "how much
+    corroboration is behind this play count".
+    """
+    if rec['play_count'] > track['play_count']:
+        track['play_count'] = rec['play_count']
+        track['play_count_source'] = source
+    track['rating'] = max(track['rating'], rec['rating'])
+    if _date_sort_key(rec['last_played']) > _date_sort_key(track['last_played']):
+        track['last_played'] = rec['last_played']
+    if count_snapshot:
+        track['snapshots'] += 1
+    track['eras'].add(era)
+    # Prefer a version of the strings that actually names an artist.
+    if rec['artist_known'] and not track['artist_known']:
+        track['artist'] = rec['artist']
+        track['title'] = rec['title']
+        track['artist_known'] = True
+
+
+def _absorb_track(target, other):
+    """Fold a title-only row into the full artist+title row it belongs to."""
+    if other['play_count'] > target['play_count']:
+        target['play_count'] = other['play_count']
+        target['play_count_source'] = other['play_count_source']
+    target['rating'] = max(target['rating'], other['rating'])
+    if _date_sort_key(other['last_played']) > _date_sort_key(target['last_played']):
+        target['last_played'] = other['last_played']
+    target['snapshots'] += other['snapshots']
+    for f in ('eras', 'playlists', 'histories'):
+        target[f] |= other[f]
+
+
+def link_title_only(tracks):
+    """Merge each title-only row into a full row whose artist+title collapses
+    to the same characters — `'Discoshaman - Making A Cyborg Edit'` is the
+    same record as artist='Discoshaman', title='Making A Cyborg Edit'.
+
+    ponytail: exact equality after normalisation only, no edit distance. A
+    fuzzy match here would silently fuse two different records in a list whose
+    whole purpose is telling the owner what to go buy; near-misses are left as
+    separate rows for a human to judge.
+    """
+    full = {}
+    for key, t in tracks.items():
+        if t['artist_known']:
+            full.setdefault(collapse(t['artist'] + t['title']), key)
+    merged = 0
+    for key in [k for k, t in tracks.items() if not t['artist_known']]:
+        target = full.get(collapse(tracks[key]['title']))
+        if target and target != key:
+            _absorb_track(tracks[target], tracks.pop(key))
+            merged += 1
+    return merged
+
+
+# ── Scan ──────────────────────────────────────────────────────────────────
+
+_SET_FIELDS = ('eras', 'playlists', 'histories')
+
+
+def new_state():
+    return {'version': STATE_VERSION, 'sources': {}, 'tracks': {},
+            'basename_index': {}}
+
+
+def _note_basename(index, basename, key):
+    """basename -> key, or None once two different tracks claim it.
+
+    Ambiguity resolves to nothing rather than to a guess: 24 of 4634 files
+    share a basename, and attributing a gig play to the wrong record is the
+    error this whole list exists to avoid.
+    """
+    if not basename:
+        return
+    if basename in index:
+        if index[basename] not in (key, None):
+            index[basename] = None
+    else:
+        index[basename] = key
+
+
+def scan(roots, state=None, job=None, reset=False):
+    """Merge every .nml/.m3u under `roots` into `state`. Returns the state.
+
+    Sources already merged and unchanged (same mtime+size) are skipped, so
+    pointing this at an external drive later adds to the picture instead of
+    rebuilding it. Every file is accounted for in state['sources'] with a
+    status — parsed, skipped or failed, always with a reason.
+    """
+    state = new_state() if (reset or not state
+                            or state.get('version') != STATE_VERSION) else state
+    sources, tracks, index = state['sources'], state['tracks'], state['basename_index']
+
+    files = find_sources(roots)
+    todo = []
+    for path in files:
+        try:
+            st = os.stat(path)
+        except OSError as exc:
+            sources[path] = {'kind': classify(path), 'status': 'failed',
+                             'error': f'{type(exc).__name__}: {exc}'}
+            continue
+        prev = sources.get(path)
+        if (prev and prev.get('status') == 'ok'
+                and prev.get('mtime') == st.st_mtime
+                and prev.get('size') == st.st_size):
+            continue
+        todo.append((path, st))
+
+    # Playlist / history membership is resolved after every collection in
+    # this run has contributed to the basename index, so a playlist listed
+    # before its own collection file still resolves.
+    #
+    # Keyed by (kind, label) rather than appended per file: the same playlist
+    # is present in all 122 collection snapshots, so a flat list would resolve
+    # 'all23' a hundred times over and report its unresolvable entries just as
+    # often — turning a number the owner is meant to read into noise.
+    pending = {}          # (kind, label) -> {basename, ...}
+    parsed = skipped = 0
+
+    for i, (path, st) in enumerate(todo, 1):
+        if job is not None and job.aborted.is_set():
+            break
+        kind, era = classify(path), era_of(path)
+        name = os.path.basename(path)
+        if job is not None:
+            job.emit('status', message=f'[{i}/{len(todo)}] {name}')
+        rec = {'kind': kind, 'era': era, 'mtime': st.st_mtime,
+               'size': st.st_size, 'status': 'ok', 'error': None, 'entries': 0}
+
+        if st.st_size == 0:
+            rec.update(status='skipped', error='empty file (0 bytes)')
+        elif is_dataless(st):
+            # Reading it here would block the whole scan — see request_download.
+            request_download(path)
+            rec.update(status='skipped',
+                       error='not downloaded from iCloud — download started, '
+                             'scan again once Finder shows it as local')
+        else:
+            try:
+                if kind == 'm3u':
+                    lines = parse_m3u(path)
+                    rec['entries'] = len(lines)
+                    pending.setdefault(('playlist', f'{name} (m3u)'), set()).update(
+                        path_basename(l) for l in lines)
+                else:
+                    doc = parse_nml(path)
+                    rec['entries'] = len(doc['entries'])
+                    is_history = kind == 'history'
+                    for entry in doc['entries']:
+                        track = tracks.setdefault(entry['key'], _new_track(entry))
+                        _absorb_entry(track, entry, path, era,
+                                      count_snapshot=not is_history)
+                        if is_history:
+                            track['histories'].add(name)
+                        else:
+                            _note_basename(index, entry['basename'], entry['key'])
+                    for pl_name, keys in doc['playlists']:
+                        slot = ('history', name) if is_history \
+                            else ('playlist', pl_name)
+                        pending.setdefault(slot, set()).update(
+                            path_basename(k) for k in keys)
+            except ET.ParseError as exc:
+                rec.update(status='failed', error=f'malformed XML: {exc}')
+            except (OSError, UnicodeError) as exc:
+                rec.update(status='failed',
+                           error=f'{type(exc).__name__}: {exc}')
+
+        sources[path] = rec
+        parsed += rec['status'] == 'ok'
+        skipped += rec['status'] != 'ok'
+
+    unresolved = 0
+    for (kind, label), basenames in pending.items():
+        field = 'histories' if kind == 'history' else 'playlists'
+        for basename in basenames:
+            key = index.get(basename)
+            if key and key in tracks:
+                tracks[key][field].add(label)
+            else:
+                unresolved += 1
+
+    linked = link_title_only(tracks)
+    # Every figure here describes the whole list, not just this run — they are
+    # shown to the owner as caveats on the data, and an incremental re-scan
+    # that read nothing new would otherwise reset them all to zero while the
+    # merges and dropped references they describe are still in force.
+    prior = state.get('stats') or {}
+    state['stats'] = {
+        'files_parsed': sum(1 for r in sources.values() if r.get('status') == 'ok'),
+        'files_skipped': sum(1 for r in sources.values() if r.get('status') != 'ok'),
+        'files_read_this_run': parsed + skipped,
+        'tracks': len(tracks),
+        'title_only_merged': prior.get('title_only_merged', 0) + linked,
+        'unresolved_path_refs': (prior.get('unresolved_path_refs', 0)
+                                 + unresolved),
+    }
+    return state
+
+
+# ── Persistence ───────────────────────────────────────────────────────────
+
+def state_path(library_db_path):
+    return os.path.join(os.path.dirname(library_db_path), 'traktor_recovery.json')
+
+
+def load_state(path):
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            state = json.load(f)
+    except (OSError, ValueError):
+        return new_state()
+    if state.get('version') != STATE_VERSION:
+        return new_state()
+    for track in state.get('tracks', {}).values():
+        for field in _SET_FIELDS:
+            track[field] = set(track.get(field) or ())
+    return state
+
+
+def save_state(state, path):
+    out = dict(state)
+    out['tracks'] = {
+        key: {**track, **{f: sorted(track[f]) for f in _SET_FIELDS}}
+        for key, track in state['tracks'].items()
+    }
+    tmp = path + '.tmp'
+    with open(tmp, 'w', encoding='utf-8') as f:
+        json.dump(out, f)
+    os.replace(tmp, path)       # never leave a half-written recovery list
+
+
+# ── Library matching ──────────────────────────────────────────────────────
+
+def annotate_library(tracks, db_path):
+    """Mark which recovered tracks are already back in beets.
+
+    Same read-only sqlite route `/unimported` takes, and the same reason it
+    matches on (artist, title) rather than path: beets' stored paths don't
+    survive a reimport, and neither do Traktor's.
+
+    Title-only rows can only be matched on title, which is a weaker claim —
+    they get `library_match: 'title-only'` so the UI never presents a guess
+    as a confirmed hit.
+    """
+    import sqlite3
+    full, titles = set(), set()
+    try:
+        con = sqlite3.connect(f'file:{db_path}?mode=ro', uri=True)
+    except sqlite3.Error:
+        return
+    try:
+        for artist, title in con.execute(
+                'SELECT DISTINCT artist, title FROM items'):
+            key, known = track_key(artist or '', title or '')
+            if known:
+                full.add(key)
+                full.add(collapse((artist or '') + (title or '')))
+            titles.add(norm_title(title or ''))
+    finally:
+        con.close()
+
+    for track in tracks.values():
+        if track['artist_known']:
+            key, _ = track_key(track['artist'], track['title'])
+            hit = (key in full
+                   or collapse(track['artist'] + track['title']) in full)
+            track['library_match'] = 'exact' if hit else None
+        else:
+            hit = norm_title(track['title']) in titles
+            track['library_match'] = 'title-only' if hit else None
+
+
+# ── Output ────────────────────────────────────────────────────────────────
+
+def assumptions(state):
+    """Stated in the UI beside the numbers, not buried here (#42).
+
+    The owner has to be able to tell which figures are estimates.
+    """
+    eras = {rec.get('era') for rec in state.get('sources', {}).values()
+            if rec.get('status') == 'ok'}
+    stats = state.get('stats', {})
+    return [
+        f'Play count is the highest value seen for a track across '
+        f'{stats.get("files_parsed", 0)} source files in {len(eras)} Traktor '
+        f'installations — not a total. Native Instruments does not document '
+        f'whether rebuilding a collection resets the count, so summing could '
+        f'inflate and taking the newest could lose a number an older backup '
+        f'still holds. The maximum can only under-report.',
+        f'{stats.get("unresolved_path_refs", 0)} playlist/history entries '
+        f'referenced a file that no snapshot could identify, and are not '
+        f'counted against any track.',
+        f'{stats.get("title_only_merged", 0)} title-only rows were merged '
+        f'into a matching artist+title row. Rows still marked "artist '
+        f'unknown" are ones Traktor never recorded an artist for.',
+    ]
+
+
+_SORTS = {
+    'play_count': lambda t: (t['play_count'], len(t['histories']),
+                             len(t['playlists'])),
+    'histories': lambda t: (len(t['histories']), t['play_count'],
+                            len(t['playlists'])),
+    'playlists': lambda t: (len(t['playlists']), t['play_count'],
+                            len(t['histories'])),
+    'rating': lambda t: (t['rating'], t['play_count']),
+}
+
+
+def results(state, sort='play_count', missing_only=True, limit=200, offset=0):
+    rows = [t for t in state['tracks'].values()
+            if not (missing_only and t.get('library_match'))]
+    rows.sort(key=_SORTS.get(sort, _SORTS['play_count']), reverse=True)
+    total = len(rows)
+    page = [{
+        'artist': t['artist'] if t['artist_known'] else None,
+        'title': t['title'],
+        'play_count': t['play_count'],
+        'play_count_source': (os.path.basename(t['play_count_source'])
+                              if t['play_count_source'] else None),
+        'rating': round(t['rating'] / 51) if t['rating'] else 0,
+        'last_played': t['last_played'],
+        'snapshots': t['snapshots'],
+        'eras': len(t['eras']),
+        'playlists': sorted(t['playlists'])[:8],
+        'playlist_count': len(t['playlists']),
+        'histories': len(t['histories']),
+        'library_match': t.get('library_match'),
+    } for t in rows[offset:offset + limit]]
+    return {'total': total, 'tracks': page}
+
+
+def source_report(state):
+    """Every file, with why it did or didn't contribute. Nothing is dropped
+    silently — that is one of the issue's acceptance criteria."""
+    out = []
+    for path, rec in sorted(state.get('sources', {}).items()):
+        out.append({'path': path, 'name': os.path.basename(path),
+                    'kind': rec.get('kind'), 'status': rec.get('status'),
+                    'error': rec.get('error'), 'entries': rec.get('entries', 0)})
+    return out
+
+
+# ── Job ───────────────────────────────────────────────────────────────────
+
+def _run(job):
+    path = job.meta['state_path']
+    state = new_state() if job.meta.get('reset') else load_state(path)
+    state = scan(job.meta['roots'], state, job=job,
+                 reset=bool(job.meta.get('reset')))
+    if job.meta.get('db_path'):
+        annotate_library(state['tracks'], job.meta['db_path'])
+    save_state(state, path)
+    job.result.update(state.get('stats', {}))
+
+
+def start(roots, state_path_, db_path=None, reset=False):
+    """Start a Traktor recovery scan. Raises RuntimeError if a job is running."""
+    job = jobs.Job('traktor', roots=roots, state_path=state_path_,
+                   db_path=db_path, reset=bool(reset))
+    return jobs.start(job, _run)


### PR DESCRIPTION
## Summary
- New `/traktor/scan/start` + `/traktor/results` endpoints and a **Recover** tab that rebuild a ranked, deduplicated most-played/most-curated list from old `collection.nml`, `history_*.nml` and `.m3u` files.
- Play count = max seen across every snapshot (NI doesn't document reset-on-rebuild behavior, and the max is correct under either answer — never inflates). Stated as an assumption in the UI, not just in code.
- Rows with no recorded ARTIST (~33% of entries, measured across two real snapshots) are kept marked "artist unknown" rather than guessed — a wrong guess sends the owner hunting for a record that doesn't exist.
- iCloud placeholders are skipped + re-downloaded in the background, never blocked on (an earlier blocking approach stalled a scan indefinitely on real files).
- Read-only on every source file. Scans are incremental (unchanged files skipped on re-run) so a later external-drive find adds to the list instead of rebuilding it.

Closes #42.

## Test plan
- [x] `python3 test_traktor.py` — 12 tests, merge/normalisation/incremental-scan/library-match logic on synthetic NML fixtures
- [x] `python3 test_jobs.py` — unaffected
- [x] Ran against the owner's real Traktor files (218 sources, 214 parsed) — verified output by hand (max-playcount rule visibly recovers a track whose newer snapshot had reset to 0; conflicting title-decoration formats correctly kept separate rows)
- [x] End-to-end through the Flask job/SSE system and the Recover tab in-browser (scan, sort, missing-only filter, source-file report)
- [x] Confirmed no source `.nml`/`.m3u` file was modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)