### PR TITLE
In-app track playback, queue, sort and search for Library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,6 @@ jobs:
 
       - name: Run test_jobs.py
         run: python test_jobs.py
+
+      - name: Run test_playback.py
+        run: python test_playback.py

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ No Electron. No Docker. Just a small Flask server and a single HTML file.
 ## Features
 
 - **Inbox** — scan a folder for music not yet in your library (matches on artist/title, not path, so it's correct however previous imports were copied or moved), then import with a keyboard-driven decision queue for matches and duplicates
-- **Library** — search and browse your collection, manage duplicates, cover art and metadata, convert WAV/AIFF/FLAC to ALAC, remove tracks
+- **Library** — search and browse your collection by album, track or artist with a sort control, play tracks in the app with a queue and a seekable transport, manage duplicates, cover art and metadata, convert WAV/AIFF/FLAC to ALAC, remove tracks
 - **Export** — playlists and tracklists for Lexicon/Traktor, USB mirror
 - **Preferences** (⚙ in the header, or ⌘,) — library/import/plugin config with a live `config.yaml` preview, and Discogs/MusicBrainz/Beatport4 credentials
 - Dark + light mode (follows macOS system preference)
@@ -132,6 +132,11 @@ Test it end to end (needs ffmpeg; runs against a throwaway library):
 - Lossless files (WAV, AIFF, FLAC) convert to **ALAC 24-bit** on import — 32-bit float is handled automatically
 - MP3 and AAC are never re-encoded
 - Designed for Traktor / Lexicon / Rekordbox workflows
+- In-app playback decodes in the browser, so it inherits the browser's codec
+  support. Safari plays everything this app produces, including ALAC and AIFF;
+  Chrome plays MP3, AAC, FLAC and WAV but **not ALAC or AIFF**, so a library
+  converted to ALAC on import is Safari-only for preview. Unplayable files say
+  so in the player bar rather than failing silently.
 
 ## Beets plugins supported in Settings UI
 

--- a/beetsgui.html
+++ b/beetsgui.html
@@ -128,6 +128,32 @@
   .lib-row-meta { color:var(--text3); font-size:10px; letter-spacing:0.04em; white-space:nowrap; }
   .lib-empty { color:var(--text3); font-size:12px; padding:1.5rem; text-align:center; }
   .lib-count { color:var(--text3); font-size:10px; letter-spacing:0.06em; text-transform:uppercase; margin-bottom:0.5rem; }
+  .lib-row-actions { display:flex; gap:0.3rem; flex-shrink:0; }
+  .row-btn { background:none; border:1px solid var(--border2); border-radius:var(--radius); color:var(--text2); cursor:pointer; font-family:inherit; font-size:11px; line-height:1.1; padding:0.2rem 0.4rem; }
+  .row-btn:hover { border-color:var(--accent); color:var(--accent); }
+  .lib-row.playing .lib-row-title,.lib-row.playing .lib-row-artist { color:var(--accent); }
+  .lib-row-link { cursor:pointer; }
+  .lib-row-link:hover .lib-row-title { color:var(--accent); }
+  /* Player: a sibling of .content, so playback survives a tab switch. The
+     <audio> keeps its native controls — that transport is the seek bar,
+     the volume slider and the elapsed/total readout, for no code. It's
+     given most of the bar's width so the scrub bar is long enough to drag
+     accurately; .player-now caps out rather than competing for space. */
+  .player { display:flex; align-items:center; gap:0.6rem; flex-shrink:0; border-top:1px solid var(--border); background:var(--bg2); padding:0.5rem 1.25rem; }
+  .player-now { flex:0 1 180px; min-width:90px; }
+  .player-title { color:var(--text); font-size:12px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .player-meta { color:var(--text3); font-size:10px; letter-spacing:0.04em; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .player-meta.err { color:var(--red); }
+  .player audio { flex:2 1 260px; min-width:220px; height:32px; color-scheme:dark; }
+  /* Queue: a floating popover anchored above the bar, not a panel in normal
+     flow — opening it must not shrink .content's visible height. */
+  .player-queue { position:fixed; right:1.25rem; width:320px; max-width:calc(100vw - 2.5rem); max-height:55vh; overflow:auto; background:var(--bg2); border:1px solid var(--border2); border-radius:var(--radius-lg); box-shadow:0 8px 28px rgba(0,0,0,0.4); z-index:60; }
+  .player-queue .lib-row { cursor:pointer; }
+  .player-queue .lib-row:hover { background:var(--bg3); }
+  @media (prefers-color-scheme:light) {
+    .player audio { color-scheme:light; }
+    .player-queue { box-shadow:0 8px 28px rgba(0,0,0,0.18); }
+  }
   /* Indeterminate progress cue for a running background job — the app can't
      show a real percentage (mbsync/bpsync don't report counts at all), so
      this signals "still alive" rather than "how far along." */
@@ -359,15 +385,23 @@
       </div>
       <div class="section">
         <div class="section-title">Your library</div>
+        <div class="check-group" style="flex-direction:row;gap:1.1rem;margin-bottom:0.6rem;">
+          <label class="radio-item"><input type="radio" name="lib-mode" value="albums" checked onchange="setLibMode()"><span>Albums</span></label>
+          <label class="radio-item"><input type="radio" name="lib-mode" value="tracks" onchange="setLibMode()"><span>Tracks</span></label>
+          <label class="radio-item"><input type="radio" name="lib-mode" value="artists" onchange="setLibMode()"><span>Artists</span></label>
+        </div>
+        <div class="field-row" style="margin-bottom:0.75rem;">
+          <div class="field">
+            <label>Sort by</label>
+            <select id="lib-sort" onchange="loadLibrary()"></select>
+          </div>
+          <button class="btn btn-sm" id="lib-dir" onclick="toggleLibDir()">↑ Asc</button>
+        </div>
         <div class="lib-count" id="lib-count"></div>
         <div class="lib-results" id="lib-results"><div class="lib-empty">Loading…</div></div>
       </div>
       <div class="section">
-        <div class="section-title">View</div>
-        <div class="check-group" style="margin-bottom:0.5rem;">
-          <label class="radio-item"><input type="radio" name="lib-type" value="" checked onchange="buildLibCmd()"><span>Tracks (default)</span></label>
-          <label class="radio-item"><input type="radio" name="lib-type" value="-a" onchange="buildLibCmd()"><span>Albums</span> <span class="mono">-a</span></label>
-        </div>
+        <div class="section-title">Command</div>
         <div class="field">
           <label><span>Output format</span> <span class="mono">-f</span>
             <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Use $artist, $album, $year, $title, $format, $bitrate, $path etc. to shape output.</span></span>
@@ -785,6 +819,19 @@
     </div>
   </dialog>
 
+  </div>
+
+  <div class="player-queue" id="player-queue" style="display:none"></div>
+  <div class="player" id="player-bar" style="display:none">
+    <div class="player-now">
+      <div class="player-title" id="player-title"></div>
+      <div class="player-meta" id="player-meta"></div>
+    </div>
+    <audio id="player-audio" controls preload="metadata"></audio>
+    <button class="row-btn" onclick="playStep(-1)" title="Previous">⏮</button>
+    <button class="row-btn" onclick="playStep(1)" title="Next">⏭</button>
+    <button class="row-btn" id="queue-btn" onclick="toggleQueue()" title="Queue">Queue</button>
+    <button class="row-btn" onclick="stopPlayback()" title="Stop and clear queue">✕</button>
   </div>
 
   <details class="cmd-box" id="cmd-box">
@@ -1332,7 +1379,10 @@ function buildLibCmd(){
   const q=document.getElementById('lib-query').value.trim();
   const field=document.getElementById('lib-field').value;
   const fval=document.getElementById('lib-field-val').value.trim();
-  const type=document.querySelector('input[name="lib-type"]:checked').value;
+  // Same Albums/Tracks/Artists choice that drives the results panel — beet
+  // ls has no "list artists" mode, so Artists falls back to plain track
+  // listing here, same as the default.
+  const type=libMode==='albums'?'-a':'';
   const fmt=document.getElementById('lib-format').value.trim();
   const exp=document.getElementById('lib-export').checked;
   let parts=['beet ls'];
@@ -1353,37 +1403,251 @@ function fmtDuration(sec){
   const m=Math.floor(sec/60),s=sec%60;
   return m+':'+String(s).padStart(2,'0');
 }
-let libLoadSeq=0;
+// The Library results panel: three row shapes over three endpoints, one
+// search box. Only tracks carry an item id, so only tracks are playable —
+// an album row plays by fetching its tracks first.
+const LIB_MODES={
+  albums: {url:'/library',         key:'albums',  noun:'album',
+           sorts:[['artist','Artist'],['album','Album'],['year','Year'],['added','Date added']]},
+  tracks: {url:'/library/tracks',  key:'tracks',  noun:'track',
+           sorts:[['artist','Artist'],['album','Album'],['title','Title'],['year','Year'],['added','Date added']]},
+  artists:{url:'/library/artists', key:'artists', noun:'artist',
+           sorts:[['artist','Name'],['tracks','Track count'],['added','Date added']]},
+};
+let libMode='albums',libDir='asc',libLoadSeq=0,libTracks=[];
+
+function setLibMode(){
+  libMode=document.querySelector('input[name="lib-mode"]:checked').value;
+  fillLibSorts();
+  loadLibrary();
+  buildLibCmd();
+}
+// The Tracks sort dropdown also offers every other real metadata column
+// (bpm, initial_key, genres, label, ...) — fetched once from /info/fields
+// rather than hardcoded, so it stays in sync with whatever this beets
+// install's schema actually has. The backend independently re-validates
+// whatever key is chosen, so this list is a UI convenience, not a trust
+// boundary.
+let allItemColumns=null;
+function loadFieldOptions(){
+  if(allItemColumns)return Promise.resolve(allItemColumns);
+  return fetch('/info/fields').then(r=>r.json())
+    .then(d=>allItemColumns=(d.ok&&d.item_columns)||[])
+    .catch(()=>allItemColumns=[]);
+}
+function fillLibSorts(){
+  const sel=document.getElementById('lib-sort'),prev=sel.value,sorts=LIB_MODES[libMode].sorts;
+  sel.innerHTML=sorts.map(s=>'<option value="'+s[0]+'">'+s[1]+'</option>').join('');
+  if(sorts.some(s=>s[0]===prev))sel.value=prev;
+  if(libMode!=='tracks')return;
+  const known=new Set(sorts.map(s=>s[0]).concat(['id','path','album_id']));
+  loadFieldOptions().then(cols=>{
+    if(libMode!=='tracks'||sel!==document.getElementById('lib-sort'))return;
+    const extra=cols.filter(c=>!known.has(c));
+    if(!extra.length)return;
+    sel.insertAdjacentHTML('beforeend','<optgroup label="All fields">'+
+      extra.map(c=>'<option value="'+c+'">'+c+'</option>').join('')+'</optgroup>');
+    if(extra.includes(prev))sel.value=prev;
+  });
+}
+function toggleLibDir(){
+  libDir=libDir==='asc'?'desc':'asc';
+  document.getElementById('lib-dir').textContent=libDir==='asc'?'↑ Asc':'↓ Desc';
+  loadLibrary();
+}
 function loadLibrary(){
   const q=document.getElementById('lib-query').value.trim();
-  const seq=++libLoadSeq;
-  fetch('/library?q='+encodeURIComponent(q)+'&limit=200')
+  const mode=LIB_MODES[libMode],seq=++libLoadSeq;
+  fetch(mode.url+'?q='+encodeURIComponent(q)+'&limit=200'+
+        '&sort='+encodeURIComponent(document.getElementById('lib-sort').value)+'&dir='+libDir)
     .then(r=>r.json())
-    .then(data=>{ if(seq===libLoadSeq)renderLibrary(data,q); })
-    .catch(()=>{ if(seq===libLoadSeq)renderLibrary({ok:false},q); });
+    .then(data=>{ if(seq===libLoadSeq)renderLibrary(data,q,mode); })
+    .catch(()=>{ if(seq===libLoadSeq)renderLibrary({ok:false},q,mode); });
 }
-function renderLibrary(data,q){
+function renderLibrary(data,q,mode){
   const el=document.getElementById('lib-results'),count=document.getElementById('lib-count');
+  libTracks=[];
   if(!data.ok){
     count.textContent='';
     el.innerHTML='<div class="lib-empty">Could not reach the library. Is the server running?</div>';
     return;
   }
-  if(!data.albums.length){
+  const rows=data[mode.key];
+  if(!rows.length){
     count.textContent='';
-    el.innerHTML='<div class="lib-empty">'+(q?'No albums match "'+escapeHtml(q)+'".':'No albums yet — import some music to get started.')+'</div>';
+    el.innerHTML='<div class="lib-empty">'+(q
+      ?'No '+mode.noun+'s match "'+escapeHtml(q)+'".'
+      :'No '+mode.noun+'s yet — import some music to get started.')+'</div>';
     return;
   }
-  count.textContent=data.total+' album'+(data.total===1?'':'s');
-  el.innerHTML=data.albums.map(a=>
-    '<div class="lib-row">'+
-      '<div class="lib-row-title"><span class="lib-row-artist">'+escapeHtml(a.albumartist||'Unknown artist')+'</span>'+
-      ' — '+escapeHtml(a.album||'Untitled')+
-      (a.year?' <span class="lib-row-year">('+a.year+')</span>':'')+'</div>'+
-      '<div class="lib-row-meta">'+(a.format||'')+' · '+a.track_count+' track'+(a.track_count===1?'':'s')+' · '+fmtDuration(a.duration)+'</div>'+
-    '</div>'
-  ).join('');
+  count.textContent=data.total+' '+mode.noun+(data.total===1?'':'s');
+  if(libMode==='tracks')libTracks=rows;
+  el.innerHTML=rows.map(libMode==='albums'?albumRow:libMode==='tracks'?trackRow:artistRow).join('');
+  markPlayingRow();
 }
+function albumRow(a){
+  return '<div class="lib-row">'+
+    '<div class="lib-row-title" style="flex:1;min-width:0;"><span class="lib-row-artist">'+escapeHtml(a.albumartist||'Unknown artist')+'</span>'+
+    ' — '+escapeHtml(a.album||'Untitled')+
+    (a.year?' <span class="lib-row-year">('+a.year+')</span>':'')+'</div>'+
+    '<div class="lib-row-meta">'+(a.format||'')+' · '+a.track_count+' track'+(a.track_count===1?'':'s')+' · '+fmtDuration(a.duration)+'</div>'+
+    '<div class="lib-row-actions">'+
+      '<button class="row-btn" onclick="playAlbum('+a.id+',false)" title="Play album">▶</button>'+
+      '<button class="row-btn" onclick="playAlbum('+a.id+',true)" title="Add album to queue">+</button>'+
+    '</div></div>';
+}
+function trackRow(t,i){
+  return '<div class="lib-row" data-track="'+t.id+'">'+
+    '<div class="lib-row-title" style="flex:1;min-width:0;"><span class="lib-row-artist">'+escapeHtml(t.artist||'Unknown artist')+'</span>'+
+    ' — '+escapeHtml(t.title||'Untitled')+'</div>'+
+    '<div class="lib-row-meta">'+escapeHtml(t.format||'')+' · '+fmtDuration(t.length)+'</div>'+
+    '<div class="lib-row-actions">'+
+      '<button class="row-btn" onclick="playFromResults('+i+')" title="Play from here">▶</button>'+
+      '<button class="row-btn" onclick="addToQueue([libTracks['+i+']])" title="Add to queue">+</button>'+
+    '</div></div>';
+}
+function artistRow(a){
+  // No id to play by — clicking narrows the search to this artist instead.
+  return '<div class="lib-row lib-row-link" onclick="searchArtist(this.dataset.name)" data-name="'+escapeHtml(a.name)+'">'+
+    '<div class="lib-row-title" style="flex:1;min-width:0;">'+escapeHtml(a.name||'Unknown artist')+'</div>'+
+    '<div class="lib-row-meta">'+a.albums+' album'+(a.albums===1?'':'s')+' · '+a.tracks+' track'+(a.tracks===1?'':'s')+'</div>'+
+    '</div>';
+}
+function searchArtist(name){
+  document.getElementById('lib-query').value=name;
+  document.querySelector('input[name="lib-mode"][value="albums"]').checked=true;
+  buildLibCmd();
+  setLibMode();
+}
+
+// ── Player ────────────────────────────────────────────────────────────────────
+// Playback is a plain <audio> element pointed at /stream/<item id>. The
+// browser does the decoding, the buffering and the Range requests that make
+// seeking work, so nothing here is a player — it's a queue and two buttons
+// that move through it. The bar lives outside .content, so a tab switch
+// doesn't interrupt what's playing.
+let queue=[],queueIdx=-1,queueOpen=false;
+
+function trackLabel(t){return (t.artist||'Unknown artist')+' — '+(t.title||'Untitled');}
+function playFromResults(i){playQueue(libTracks,i);}
+function playQueue(tracks,idx){
+  if(!tracks.length)return;
+  queue=tracks.slice();queueIdx=idx||0;playCurrent();
+}
+function addToQueue(tracks){
+  if(!tracks.length)return;
+  const wasEmpty=!queue.length;
+  queue=queue.concat(tracks);
+  if(wasEmpty){queueIdx=0;playCurrent();}else renderPlayer();
+}
+function playAlbum(albumId,append){
+  fetch('/library/tracks?album_id='+albumId+'&sort=album&limit=1000')
+    .then(r=>r.json())
+    .then(d=>{ if(d.ok&&d.tracks.length)append?addToQueue(d.tracks):playQueue(d.tracks,0); })
+    .catch(()=>{});
+}
+function playStep(d){
+  const next=queueIdx+d;
+  if(next<0||next>=queue.length)return;  // stops at both ends: no wrap, no shuffle
+  playAt(next);
+}
+function playAt(i){queueIdx=i;playCurrent();}
+function playCurrent(){
+  const a=document.getElementById('player-audio'),t=queue[queueIdx];
+  if(!t)return stopPlayback();
+  a.src='/stream/'+t.id;
+  a.play().catch(()=>{});  // a failed load reports itself through the error event
+  setNowPlaying(t);
+  renderPlayer();
+}
+function stopPlayback(){
+  const a=document.getElementById('player-audio');
+  a.pause();a.removeAttribute('src');a.load();
+  queue=[];queueIdx=-1;queueOpen=false;
+  if('mediaSession' in navigator){navigator.mediaSession.metadata=null;navigator.mediaSession.playbackState='none';}
+  renderPlayer();
+}
+function toggleQueue(){queueOpen=!queueOpen;renderPlayer();}
+
+// ── macOS media keys / Now Playing (Control Center, Touch Bar, notch
+// widgets like Boring Notch) ─────────────────────────────────────────────
+// All of it runs through the Media Session API — the browser is what talks
+// to the OS, this just feeds it. Safari populates the system Now Playing
+// info from exactly this; nothing notch-specific to add.
+function setNowPlaying(t){
+  if(!('mediaSession' in navigator))return;
+  navigator.mediaSession.metadata=new MediaMetadata({
+    title: t.title||'Untitled', artist: t.artist||'Unknown artist', album: t.album||'',
+    artwork: t.album_id?[{src:'/art/'+t.album_id,sizes:'600x600',type:'image/jpeg'}]:[],
+  });
+}
+function renderPlayer(){
+  const bar=document.getElementById('player-bar'),qEl=document.getElementById('player-queue'),t=queue[queueIdx];
+  bar.style.display=t?'flex':'none';
+  if(!t){qEl.style.display='none';markPlayingRow();return;}
+  document.getElementById('player-title').textContent=trackLabel(t);
+  const meta=document.getElementById('player-meta');
+  meta.className='player-meta';
+  meta.textContent=[t.album,t.format,fmtDuration(t.length)].filter(Boolean).join(' · ')+
+    ' · '+(queueIdx+1)+' of '+queue.length;
+  document.getElementById('queue-btn').textContent='Queue '+queue.length;
+  // A popover, not a panel in the page flow — anchored just above the bar
+  // so opening it never shrinks the results list underneath. Measured from
+  // the bar's actual screen position, not just its own height: the command
+  // box sits below it in normal flow, so the bar usually isn't flush with
+  // the viewport bottom.
+  qEl.style.bottom=(window.innerHeight-bar.getBoundingClientRect().top)+'px';
+  qEl.style.display=queueOpen?'block':'none';
+  qEl.innerHTML=queue.map((q,i)=>
+    '<div class="lib-row'+(i===queueIdx?' playing':'')+'" onclick="playAt('+i+')">'+
+      '<div class="lib-row-title" style="flex:1;min-width:0;">'+escapeHtml(trackLabel(q))+'</div>'+
+      '<div class="lib-row-meta">'+fmtDuration(q.length)+'</div></div>').join('');
+  markPlayingRow();
+}
+function markPlayingRow(){
+  const id=queue[queueIdx]?String(queue[queueIdx].id):null;
+  document.querySelectorAll('#lib-results .lib-row[data-track]').forEach(r=>
+    r.classList.toggle('playing',r.dataset.track===id));
+}
+document.addEventListener('DOMContentLoaded',function(){
+  fillLibSorts();
+  const a=document.getElementById('player-audio');
+  a.addEventListener('ended',function(){playStep(1);});
+  a.addEventListener('error',function(){
+    const t=queue[queueIdx],m=document.getElementById('player-meta');
+    m.className='player-meta err';
+    m.textContent='Cannot play this '+((t&&t.format)||'file')+' — no decoder for it in this browser.';
+  });
+
+  // Queue popover: closes on an outside click or Escape, like any dropdown.
+  document.addEventListener('click',function(e){
+    if(!queueOpen)return;
+    const qEl=document.getElementById('player-queue'),btn=document.getElementById('queue-btn');
+    if(qEl.contains(e.target)||btn.contains(e.target))return;
+    queueOpen=false;renderPlayer();
+  });
+  document.addEventListener('keydown',function(e){
+    if(e.key==='Escape'&&queueOpen){queueOpen=false;renderPlayer();}
+  });
+  window.addEventListener('resize',function(){ if(queueOpen)renderPlayer(); });
+
+  if('mediaSession' in navigator){
+    a.addEventListener('play',function(){navigator.mediaSession.playbackState='playing';});
+    a.addEventListener('pause',function(){navigator.mediaSession.playbackState='paused';});
+    a.addEventListener('timeupdate',function(){
+      if(!isFinite(a.duration))return;
+      try{navigator.mediaSession.setPositionState({duration:a.duration,playbackRate:a.playbackRate||1,position:a.currentTime});}catch(e){}
+    });
+    navigator.mediaSession.setActionHandler('play',()=>a.play().catch(()=>{}));
+    navigator.mediaSession.setActionHandler('pause',()=>a.pause());
+    navigator.mediaSession.setActionHandler('stop',()=>stopPlayback());
+    navigator.mediaSession.setActionHandler('previoustrack',()=>playStep(-1));
+    navigator.mediaSession.setActionHandler('nexttrack',()=>playStep(1));
+    navigator.mediaSession.setActionHandler('seekbackward',d=>{a.currentTime=Math.max(0,a.currentTime-(d.seekOffset||10));});
+    navigator.mediaSession.setActionHandler('seekforward',d=>{a.currentTime=Math.min(a.duration||1e9,a.currentTime+(d.seekOffset||10));});
+    navigator.mediaSession.setActionHandler('seekto',d=>{a.currentTime=d.seekTime;});
+  }
+});
 
 // ── Duplicates ────────────────────────────────────────────────────────────────
 let dupGroups=[];

--- a/server.py
+++ b/server.py
@@ -19,7 +19,8 @@ import time
 from pathlib import Path
 
 try:
-    from flask import Flask, Response, request, send_from_directory, jsonify
+    from flask import (Flask, Response, request, send_file, send_from_directory,
+                       jsonify)
 except ImportError:
     print("Flask not found.")
     print("Install: pip install flask   (or: pip3 install flask)")
@@ -45,6 +46,15 @@ except ImportError as e:
 
 # Extensions scanned by /unimported — matches beets' default valid_extensions.
 AUDIO_EXTENSIONS = {'.mp3', '.aiff', '.aif', '.wav', '.flac', '.m4a', '.aac', '.ogg'}
+
+# Types the stdlib guesses wrong for /stream. mimetypes says 'audio/mp4a-latm'
+# for .m4a and 'audio/x-flac' for .flac; neither is a container Chrome
+# registers, so both play only by content-sniffing and canPlayType() lies.
+# Only formats a browser can actually decode are worth correcting — nothing
+# here rescues ALAC, AIFF or WavPack, which no amount of Content-Type makes
+# playable outside Safari. The player surfaces those as an error instead.
+AUDIO_MIMETYPES = {'.m4a': 'audio/mp4', '.mp4': 'audio/mp4',
+                   '.flac': 'audio/flac', '.opus': 'audio/ogg'}
 
 # ── Configuration ──────────────────────────────────────────────────────────────
 PORT       = int(os.environ.get('BEETSGUI_PORT', 1612))
@@ -211,25 +221,93 @@ def open_app_when_ready():
         )
 
 
+# Sort orders offered by the Library tab. The request only ever picks a key
+# here — column names never come from the query string, because this is the
+# one place in the app where user input reaches SQL that can't be a bound
+# parameter. Each value is a tuple so ?dir=desc can flip every column.
+ALBUM_SORTS = {
+    'artist': ('a.albumartist COLLATE NOCASE', 'a.year', 'a.album COLLATE NOCASE'),
+    'album':  ('a.album COLLATE NOCASE', 'a.albumartist COLLATE NOCASE'),
+    'year':   ('a.year', 'a.albumartist COLLATE NOCASE', 'a.album COLLATE NOCASE'),
+    'added':  ('a.added',),
+}
+TRACK_SORTS = {
+    'artist': ('i.artist COLLATE NOCASE', 'i.album COLLATE NOCASE', 'i.disc', 'i.track'),
+    'album':  ('i.album COLLATE NOCASE', 'i.disc', 'i.track'),
+    'title':  ('i.title COLLATE NOCASE',),
+    'year':   ('i.year', 'i.album COLLATE NOCASE', 'i.disc', 'i.track'),
+    'added':  ('i.added',),
+}
+ARTIST_SORTS = {
+    'artist': ('name COLLATE NOCASE',),
+    'added':  ('MAX(i.added)',),
+    'tracks': ('tracks',),
+}
+
+
+def _resolve_sort(con, table, alias, col):
+    """(expr,) sorting by any real column on `table`, or None if `col` isn't
+    one. Validated against the live schema on every call — the only way a
+    user-typed field name (bpm, initial_key, label, ...) can reach an ORDER
+    BY without ever being spliced in as arbitrary SQL."""
+    info = {r['name']: r['type'] for r in con.execute(f'PRAGMA table_info({table})')}
+    coltype = info.get(col)
+    if coltype is None:
+        return None
+    is_text = not coltype or any(t in coltype.upper() for t in ('CHAR', 'TEXT', 'CLOB'))
+    return (f'{alias}.{col}' + (' COLLATE NOCASE' if is_text else ''),)
+
+
+def _order_by(sorts, default, dynamic=None):
+    """ORDER BY fragment from ?sort= / ?dir=.
+
+    `sorts` is the curated, multi-column whitelist (e.g. artist sort also
+    breaks ties by album/track). `dynamic`, if given, is (con, table, alias)
+    — a fallback that accepts any other real column on that table, so sort
+    isn't limited to the fields curated here.
+    """
+    key = request.args.get('sort', default)
+    cols = sorts.get(key)
+    if cols is None and dynamic is not None:
+        cols = _resolve_sort(*dynamic, key)
+    if cols is None:
+        cols = sorts[default]
+    suffix = ' DESC' if request.args.get('dir') == 'desc' else ''
+    return ', '.join(c + suffix for c in cols)
+
+
+def _page(default_limit=200, max_limit=1000):
+    """(limit, offset) from the query string. Raises ValueError on garbage."""
+    return (min(int(request.args.get('limit', default_limit)), max_limit),
+            max(int(request.args.get('offset', 0)), 0))
+
+
+def _library_con():
+    """Read-only connection to the beets library.db, or None if there isn't one."""
+    db_path = get_library_db_path()
+    if not Path(db_path).exists():
+        return None
+    con = sqlite3.connect(f'file:{db_path}?mode=ro', uri=True)
+    con.row_factory = sqlite3.Row
+    return con
+
+
 # ── Routes ─────────────────────────────────────────────────────────────────────
 @app.route('/library')
 def library():
     """Read albums directly from the beets library.db (read-only)."""
     q = request.args.get('q', '').strip()
     try:
-        limit  = min(int(request.args.get('limit', 200)), 1000)
-        offset = max(int(request.args.get('offset', 0)), 0)
+        limit, offset = _page()
     except ValueError:
         return jsonify({'ok': False,
                         'error': 'limit and offset must be integers'}), 400
-    db_path = get_library_db_path()
 
-    if not Path(db_path).exists():
+    con = _library_con()
+    if con is None:
         return jsonify({'ok': True, 'albums': [], 'total': 0})
 
     try:
-        con = sqlite3.connect(f'file:{db_path}?mode=ro', uri=True)
-        con.row_factory = sqlite3.Row
         qlike = f'%{q}%'
         where = '''
             :q = '' OR a.albumartist LIKE :qlike OR a.album LIKE :qlike OR EXISTS (
@@ -244,7 +322,7 @@ def library():
                    (SELECT COALESCE(SUM(length), 0) FROM items i WHERE i.album_id = a.id) AS duration
             FROM albums a
             WHERE {where}
-            ORDER BY a.albumartist, a.year, a.album
+            ORDER BY {_order_by(ALBUM_SORTS, 'artist')}
             LIMIT :limit OFFSET :offset
         ''', {'q': q, 'qlike': qlike, 'limit': limit, 'offset': offset}).fetchall()
         total = con.execute(f'SELECT COUNT(*) FROM albums a WHERE {where}', {'q': q, 'qlike': qlike}).fetchone()[0]
@@ -253,6 +331,132 @@ def library():
         return jsonify({'ok': True, 'albums': albums, 'total': total})
     except sqlite3.Error as e:
         return jsonify({'ok': False, 'error': str(e)}), 500
+
+
+@app.route('/library/tracks')
+def library_tracks():
+    """Track-level rows, each with the item id /stream plays by.
+
+    A separate endpoint from /library rather than a mode flag on it: this is a
+    different row shape, not a different ordering of the same one.
+    """
+    q = request.args.get('q', '').strip()
+    album_id = request.args.get('album_id', '').strip()
+    try:
+        limit, offset = _page()
+        params = {'album_id': int(album_id)} if album_id else {}
+    except ValueError:
+        return jsonify({'ok': False,
+                        'error': 'limit, offset and album_id must be integers'}), 400
+
+    con = _library_con()
+    if con is None:
+        return jsonify({'ok': True, 'tracks': [], 'total': 0})
+
+    try:
+        params.update({'q': q, 'qlike': f'%{q}%', 'limit': limit, 'offset': offset})
+        where = '''(:q = '' OR i.title LIKE :qlike OR i.artist LIKE :qlike
+                    OR i.album LIKE :qlike OR i.albumartist LIKE :qlike)'''
+        if album_id:
+            where += ' AND i.album_id = :album_id'
+        rows = con.execute(f'''
+            SELECT i.id, i.title, i.artist, i.album, i.albumartist, i.album_id,
+                   i.year, i.length, i.format, i.track, i.disc
+            FROM items i
+            WHERE {where}
+            ORDER BY {_order_by(TRACK_SORTS, 'artist', dynamic=(con, 'items', 'i'))}
+            LIMIT :limit OFFSET :offset
+        ''', params).fetchall()
+        total = con.execute(f'SELECT COUNT(*) FROM items i WHERE {where}',
+                            params).fetchone()[0]
+        con.close()
+        return jsonify({'ok': True, 'tracks': [dict(r) for r in rows], 'total': total})
+    except sqlite3.Error as e:
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+
+@app.route('/library/artists')
+def library_artists():
+    """Album artists with their album and track counts."""
+    q = request.args.get('q', '').strip()
+    try:
+        limit, offset = _page()
+    except ValueError:
+        return jsonify({'ok': False,
+                        'error': 'limit and offset must be integers'}), 400
+
+    con = _library_con()
+    if con is None:
+        return jsonify({'ok': True, 'artists': [], 'total': 0})
+
+    try:
+        params = {'q': q, 'qlike': f'%{q}%', 'limit': limit, 'offset': offset}
+        # Tracks with no albumartist fall back to artist so nothing vanishes
+        # from this view; unattributed files group under one empty name.
+        name = "COALESCE(NULLIF(i.albumartist, ''), i.artist, '')"
+        where = f"(:q = '' OR {name} LIKE :qlike OR i.artist LIKE :qlike)"
+        rows = con.execute(f'''
+            SELECT {name} AS name,
+                   COUNT(DISTINCT i.album_id) AS albums,
+                   COUNT(*) AS tracks
+            FROM items i
+            WHERE {where}
+            GROUP BY name COLLATE NOCASE
+            ORDER BY {_order_by(ARTIST_SORTS, 'artist')}
+            LIMIT :limit OFFSET :offset
+        ''', params).fetchall()
+        total = con.execute(f'''
+            SELECT COUNT(*) FROM (
+                SELECT 1 FROM items i WHERE {where} GROUP BY {name} COLLATE NOCASE
+            )
+        ''', params).fetchone()[0]
+        con.close()
+        return jsonify({'ok': True, 'artists': [dict(r) for r in rows], 'total': total})
+    except sqlite3.Error as e:
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+
+@app.route('/stream/<int:item_id>')
+def stream(item_id):
+    """Serve one library file to the browser's <audio> element.
+
+    Addressed by item id, never by path: the only files this can ever hand
+    out are ones beets already has in its database, so there's no traversal
+    to defend against. send_file's conditional=True does the Range/206
+    handling — that, and nothing else, is what makes seeking work.
+    """
+    con = _library_con()
+    if con is None:
+        return jsonify({'ok': False, 'error': 'no library database'}), 404
+    row = con.execute('SELECT path FROM items WHERE id = ?', (item_id,)).fetchone()
+    con.close()
+    if not row:
+        return jsonify({'ok': False, 'error': 'no such track'}), 404
+
+    # beets stores paths as BLOBs of raw filesystem bytes.
+    path = os.fsdecode(row['path'])
+    if not os.path.isfile(path):
+        return jsonify({'ok': False, 'error': 'file is missing from disk'}), 404
+    return send_file(path, conditional=True,
+                     mimetype=AUDIO_MIMETYPES.get(Path(path).suffix.lower()))
+
+
+@app.route('/art/<int:album_id>')
+def album_art(album_id):
+    """Cover art for an album, if beets has any on disk. Same id-only
+    addressing as /stream — nothing here ever fetches or generates art, it
+    only serves what fetchart/embedart already put at albums.artpath."""
+    con = _library_con()
+    if con is None:
+        return jsonify({'ok': False, 'error': 'no library database'}), 404
+    row = con.execute('SELECT artpath FROM albums WHERE id = ?', (album_id,)).fetchone()
+    con.close()
+    if not row or not row['artpath']:
+        return jsonify({'ok': False, 'error': 'no art'}), 404
+    path = os.fsdecode(row['artpath'])
+    if not os.path.isfile(path):
+        return jsonify({'ok': False, 'error': 'art file is missing from disk'}), 404
+    return send_file(path, conditional=True)
 
 
 @app.route('/duplicates')
@@ -288,7 +492,15 @@ def info_stats():
 
 @app.route('/info/fields')
 def info_fields():
-    return jsonify({'ok': True, **libops.fields()})
+    data = {'ok': True, **libops.fields()}
+    # Real items columns, not beets' full Model.all_keys() (that includes
+    # flexible attributes with no SQL column) — this is specifically what
+    # the Library tab's "sort by" dropdown can safely offer.
+    con = _library_con()
+    if con is not None:
+        data['item_columns'] = sorted(r['name'] for r in con.execute('PRAGMA table_info(items)'))
+        con.close()
+    return jsonify(data)
 
 
 @app.route('/info/version')

--- a/test_playback.py
+++ b/test_playback.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Unit test for the Library browse endpoints and /stream (#58).
+
+Three things here can break silently and are worth pinning down:
+
+  * the ?sort= whitelist — it is the one place a request string reaches SQL
+    that can't be a bound parameter. A curated key (artist, title, ...) maps
+    to a fixed column list; anything else is only accepted after being
+    checked against the live schema (PRAGMA table_info), never spliced in
+    raw — an unresolvable key has to fall back to the default rather than
+    reach sqlite;
+  * Range/206 on /stream — that, and only that, is what lets the <audio>
+    element seek. A 200 with the whole body "works" in the browser right up
+    until you drag the scrubber;
+  * /art addressed by album id only, same as /stream by item id — no path
+    ever comes from the request.
+
+Runs against a synthetic library.db and a generated WAV, so no beets library
+and no real music are needed.
+
+Run: python test_playback.py
+"""
+import os
+import sqlite3
+import tempfile
+import wave
+from pathlib import Path
+
+import server
+
+BASE = f'http://localhost:{server.PORT}'  # _reject_foreign_host wants the real host
+
+
+def make_wav(path, seconds=1):
+    """A silent mono WAV — something with a real length to serve and seek in."""
+    with wave.open(str(path), 'wb') as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(8000)
+        w.writeframes(b'\0\0' * 8000 * seconds)
+
+
+def make_library(dir_path, audio_path, art_path):
+    """A library.db with the columns these endpoints actually read.
+
+    bpm/initial_key aren't used by any hardcoded sort — they're here so
+    ?sort=bpm can be exercised as a *dynamic* (schema-validated, not
+    hardcoded) sort column, same as a real beets library would offer.
+    """
+    db = dir_path / 'library.db'
+    con = sqlite3.connect(db)
+    con.executescript('''
+        CREATE TABLE albums (id INTEGER PRIMARY KEY, albumartist TEXT,
+                             album TEXT, year INTEGER, added REAL, artpath BLOB);
+        CREATE TABLE items (id INTEGER PRIMARY KEY, path BLOB, title TEXT,
+                            artist TEXT, album TEXT, albumartist TEXT,
+                            album_id INTEGER, year INTEGER, length REAL,
+                            format TEXT, track INTEGER, disc INTEGER,
+                            added REAL, bpm INTEGER, initial_key TEXT);
+    ''')
+    con.execute("INSERT INTO albums VALUES (1,'Burial','Untrue',2007,100.0,?)",
+               (os.fsencode(str(art_path)),))
+    con.execute("INSERT INTO albums VALUES (2,'Autechre','Amber',1994,200.0,NULL)")
+    con.execute(
+        'INSERT INTO items VALUES (1,?,?,?,?,?,?,?,?,?,?,?,?,?,?)',
+        (os.fsencode(str(audio_path)), 'Archangel', 'Burial', 'Untrue',
+         'Burial', 1, 2007, 1.0, 'WAV', 1, 1, 100.0, 140, 'F#m'))
+    con.execute(
+        'INSERT INTO items VALUES (2,?,?,?,?,?,?,?,?,?,?,?,?,?,?)',
+        (os.fsencode('/nonexistent/gone.flac'), 'Near Dark', 'Burial',
+         'Untrue', 'Burial', 1, 2007, 2.0, 'FLAC', 2, 1, 100.0, 122, 'Am'))
+    con.execute(
+        'INSERT INTO items VALUES (3,?,?,?,?,?,?,?,?,?,?,?,?,?,?)',
+        (os.fsencode('/nonexistent/foil.flac'), 'Foil', 'Autechre', 'Amber',
+         'Autechre', 2, 1994, 3.0, 'FLAC', 1, 1, 200.0, 160, 'Cm'))
+    con.commit()
+    con.close()
+    return db
+
+
+def main():
+    tmp = tempfile.TemporaryDirectory()
+    root = Path(tmp.name)
+    audio = root / 'archangel.wav'
+    art = root / 'cover.jpg'
+    make_wav(audio)
+    art.write_bytes(b'\xff\xd8\xff\xe0fake jpeg')
+    db = make_library(root, audio, art)
+
+    # The real one shells out to `beet config --path`; this test has no beets
+    # library and doesn't need one.
+    server.get_library_db_path = lambda: str(db)
+    client = server.app.test_client()
+
+    def get(path, **kw):
+        return client.get(path, base_url=BASE, **kw)
+
+    # ── browse ────────────────────────────────────────────────────────────
+    r = get('/library')
+    assert r.status_code == 200, r.status_code
+    assert [a['album'] for a in r.json['albums']] == ['Amber', 'Untrue'], r.json
+
+    r = get('/library/tracks')
+    assert r.json['total'] == 3, r.json
+    assert r.json['tracks'][0]['title'] == 'Foil', r.json  # Autechre sorts first
+
+    r = get('/library/tracks?album_id=1')
+    assert [t['title'] for t in r.json['tracks']] == ['Archangel', 'Near Dark'], r.json
+
+    r = get('/library/tracks?q=archangel')
+    assert [t['id'] for t in r.json['tracks']] == [1], r.json
+
+    r = get('/library/artists')
+    assert [(a['name'], a['albums'], a['tracks']) for a in r.json['artists']] == \
+        [('Autechre', 1, 1), ('Burial', 1, 2)], r.json
+
+    r = get('/library/tracks?album_id=notanumber')
+    assert r.status_code == 400, r.status_code
+
+    # ── sorting ───────────────────────────────────────────────────────────
+    asc = [t['title'] for t in get('/library/tracks?sort=title').json['tracks']]
+    desc = [t['title'] for t in get('/library/tracks?sort=title&dir=desc').json['tracks']]
+    assert asc == ['Archangel', 'Foil', 'Near Dark'], asc
+    assert desc == list(reversed(asc)), desc
+
+    years = [a['year'] for a in get('/library?sort=year&dir=desc').json['albums']]
+    assert years == [2007, 1994], years
+
+    # An unknown or hostile sort key falls back to the default; nothing from
+    # the query string is ever spliced into the ORDER BY.
+    for hostile in ('bogus', '1; DROP TABLE items--', "a' OR '1'='1"):
+        r = get('/library/tracks?sort=' + hostile)
+        assert r.status_code == 200, (hostile, r.status_code)
+        assert [t['title'] for t in r.json['tracks']] == ['Foil', 'Archangel', 'Near Dark'], \
+            (hostile, r.json)
+    assert get('/library/tracks').json['total'] == 3, 'items table survived'
+
+    # A real column that isn't in TRACK_SORTS (bpm, an ID3-ish field a user
+    # picked from the "All fields" dropdown) resolves dynamically.
+    bpm_asc = [t['title'] for t in get('/library/tracks?sort=bpm').json['tracks']]
+    assert bpm_asc == ['Near Dark', 'Archangel', 'Foil'], bpm_asc  # 122, 140, 160
+    key_desc = [t['title'] for t in get('/library/tracks?sort=initial_key&dir=desc').json['tracks']]
+    assert key_desc == ['Archangel', 'Foil', 'Near Dark'], key_desc  # F#m, Cm, Am
+
+    # A column absent from *this* items table (e.g. a real beets field this
+    # synthetic schema doesn't include) falls back the same way a bogus
+    # string does — the dynamic path is schema-checked, not name-checked.
+    fallback = [t['title'] for t in get('/library/tracks?sort=composers').json['tracks']]
+    assert fallback == ['Foil', 'Archangel', 'Near Dark'], fallback  # default order
+
+    # ── streaming ─────────────────────────────────────────────────────────
+    body = audio.read_bytes()
+
+    r = get('/stream/1')
+    assert r.status_code == 200, r.status_code
+    assert r.data == body, (len(r.data), len(body))
+    assert r.headers['Content-Type'].startswith('audio/'), r.headers['Content-Type']
+    assert r.headers.get('Accept-Ranges') == 'bytes', dict(r.headers)
+
+    # The seek guarantee: a Range request must come back as a 206 with only
+    # the bytes asked for, or dragging the scrubber restarts the download.
+    r = get('/stream/1', headers={'Range': 'bytes=100-199'})
+    assert r.status_code == 206, r.status_code
+    assert r.data == body[100:200], (len(r.data), r.headers.get('Content-Range'))
+    assert r.headers['Content-Range'] == f'bytes 100-199/{len(body)}', r.headers['Content-Range']
+
+    assert get('/stream/2').status_code == 404, 'file missing from disk'
+    assert get('/stream/9999').status_code == 404, 'no such item'
+
+    # A path can only ever come out of the database, so there is no traversal
+    # surface — the route doesn't accept anything but an integer id.
+    assert get('/stream/../../etc/passwd').status_code == 404
+
+    # ── cover art ─────────────────────────────────────────────────────────
+    r = get('/art/1')
+    assert r.status_code == 200, r.status_code
+    assert r.data == art.read_bytes()
+    assert get('/art/2').status_code == 404, 'album has no artpath'
+    assert get('/art/9999').status_code == 404, 'no such album'
+
+    # ── /info/fields' item_columns (feeds the Tracks sort dropdown) ────────
+    cols = get('/info/fields').json['item_columns']
+    assert {'bpm', 'initial_key', 'title', 'artist'} <= set(cols), cols
+
+    # ── no library at all ─────────────────────────────────────────────────
+    server.get_library_db_path = lambda: str(root / 'gone.db')
+    assert get('/library').json == {'ok': True, 'albums': [], 'total': 0}
+    assert get('/library/tracks').json == {'ok': True, 'tracks': [], 'total': 0}
+    assert get('/library/artists').json == {'ok': True, 'artists': [], 'total': 0}
+    assert get('/stream/1').status_code == 404
+    assert get('/art/1').status_code == 404
+
+    tmp.cleanup()
+    print('test_playback: all checks passed')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- In-app playback: a plain `<audio controls>` element pointed at `GET /stream/<item_id>` (`send_file(path, conditional=True, ...)` — Range/206 for free, so seeking works). No MPD/bpd, no native dependency beyond what's already required.
- A play queue: play a track/album, add to queue, next/prev, auto-advance on `ended`, a floating queue popover (not a panel that pushes the results list).
- Library browsing: `GET /library/tracks` and `GET /library/artists` alongside the existing album view, with an Albums/Tracks/Artists mode selector.
- Sort: `?sort=`/`?dir=` on all three, a curated multi-column whitelist plus a dynamic fallback validated against the live schema (`PRAGMA table_info(items)`) — so sorting by any real ID3-ish field (bpm, initial_key, genres, label, ...) works without hardcoding every one.
- Cover art: `GET /art/<album_id>`, same id-only addressing as `/stream`.
- macOS media keys / Now Playing (Control Center, Touch Bar, notch widgets): wired via the Media Session API.
- Removed a pre-existing UI duplication: two separate "Tracks/Albums" controls (one drove results, one only fed a command-string flag) collapsed into one.

Diverges from #58's suggested `bpd` (MPD) backend — see the comment on that issue for why. Full rationale and phase notes: [#58](https://github.com/fastermadman/beetsGUI/issues/58#issuecomment-5226729014).

Closes #58.

## Test plan

- [x] `python test_playback.py` — new suite: browse endpoints, curated + dynamic sort (including SQL-injection-shaped sort keys falling back safely), Range/206 correctness, `/art` id-only addressing, no-library-yet behavior.
- [x] Full existing suite still green: `test_jobs.py`, `test_transcode.py`, `test_importsession.py`, `test_traktor.py`.
- [x] Verified in-browser against a synthetic library (dark + light mode): play/pause/seek, queue add/advance/prev/next, floating queue popover positioning, custom-field sort ordering, `/art` 200/404, real `Accept-Ranges`/`206` responses over the network.
- [ ] **Not verified**: real Safari, real FLAC/ALAC/AIFF files, real macOS media-key hardware, a real Boring Notch instance, or a populated real-scale library — none of these are reachable from this session. See the #58 comment and #12 for what's left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)