### PR TITLE
Searchable field input (datalist) + server rejects unknown fields

### DIFF
--- a/beetsgui.html
+++ b/beetsgui.html
@@ -393,7 +393,7 @@
         <div class="field-row" style="margin-bottom:0.75rem;">
           <div class="field">
             <label>Sort by</label>
-            <select id="lib-sort" onchange="loadLibrary()"></select>
+            <input type="text" list="lib-sort-list" id="lib-sort" onchange="loadLibrary()" autocomplete="off"><datalist id="lib-sort-list"></datalist>
           </div>
           <button class="btn btn-sm" id="lib-dir" onclick="toggleLibDir()">↑ Asc</button>
         </div>
@@ -454,7 +454,7 @@
       <div class="section">
         <div class="section-title">Metadata</div>
         <div class="field-row">
-          <div class="field"><label>Field</label><select id="mod-field"><option value="">Loading fields…</option></select></div>
+          <div class="field"><label>Field</label><input type="text" list="beet-fields" id="mod-field" placeholder="Loading fields…" autocomplete="off"><datalist id="beet-fields"></datalist></div>
           <div class="field"><label>New value</label><input type="text" id="mod-value" placeholder="Burial"></div>
           <div class="field"><label>Query</label><input type="text" id="mod-query" placeholder="album:Untrue"></div>
         </div>
@@ -1436,18 +1436,18 @@ function loadFieldOptions(){
     .catch(()=>allItemColumns=[]);
 }
 function fillLibSorts(){
-  const sel=document.getElementById('lib-sort'),prev=sel.value,sorts=LIB_MODES[libMode].sorts;
-  sel.innerHTML=sorts.map(s=>'<option value="'+s[0]+'">'+s[1]+'</option>').join('');
-  if(sorts.some(s=>s[0]===prev))sel.value=prev;
+  const inp=document.getElementById('lib-sort'),dl=document.getElementById('lib-sort-list'),
+        prev=inp.value,sorts=LIB_MODES[libMode].sorts;
+  dl.innerHTML=sorts.map(s=>'<option value="'+s[0]+'" label="'+escapeHtml(s[1])+'">').join('');
+  inp.value=sorts.some(s=>s[0]===prev)?prev:sorts[0][0];
   if(libMode!=='tracks')return;
   const known=new Set(sorts.map(s=>s[0]).concat(['id','path','album_id']));
   loadFieldOptions().then(cols=>{
-    if(libMode!=='tracks'||sel!==document.getElementById('lib-sort'))return;
+    if(libMode!=='tracks'||inp!==document.getElementById('lib-sort'))return;
     const extra=cols.filter(c=>!known.has(c));
     if(!extra.length)return;
-    sel.insertAdjacentHTML('beforeend','<optgroup label="All fields">'+
-      extra.map(c=>'<option value="'+c+'">'+c+'</option>').join('')+'</optgroup>');
-    if(extra.includes(prev))sel.value=prev;
+    dl.insertAdjacentHTML('beforeend',extra.map(c=>'<option value="'+c+'">').join(''));
+    if(extra.includes(prev))inp.value=prev;
   });
 }
 function toggleLibDir(){
@@ -1836,18 +1836,18 @@ function dismissFirstRun(){
   document.getElementById('first-run-banner').style.display='none';
 }
 function loadModFields(){
-  const sel=document.getElementById('mod-field');
+  const inp=document.getElementById('mod-field'),dl=document.getElementById('beet-fields');
+  inp.placeholder='artist, genres, mb_albumid…';
+  const opt=f=>'<option value="'+escapeHtml(f)+'">';
   fetch('/info/fields').then(r=>r.json()).then(data=>{
     if(!data.ok)throw new Error(data.error);
     const all=data.item_fields.filter(f=>!NON_FIELDS.includes(f));
     const common=COMMON_FIELDS.filter(f=>all.includes(f));
     const rest=all.filter(f=>!common.includes(f));
-    const opt=f=>'<option value="'+escapeHtml(f)+'">'+escapeHtml(f)+'</option>';
-    sel.innerHTML=common.map(opt).join('')+
-      (rest.length?'<optgroup label="other fields">'+rest.map(opt).join('')+'</optgroup>':'');
+    dl.innerHTML=common.map(opt).join('')+rest.map(opt).join('');
   }).catch(()=>{
     // Fall back to the common list so the section still works offline.
-    sel.innerHTML=COMMON_FIELDS.map(f=>'<option value="'+f+'">'+f+'</option>').join('');
+    dl.innerHTML=COMMON_FIELDS.map(opt).join('');
   });
 }
 function showVersion(resultsId){

--- a/beetsgui.html
+++ b/beetsgui.html
@@ -428,54 +428,60 @@
       <div id="info-results"></div>
 
       <hr class="divider">
-      <div class="section">
-        <div class="section-title">
+      <details class="section">
+        <summary class="section-title">
           <span>Duplicates</span>
           <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">During import: beets ranks quality automatically and asks only when it can't tell. This scan uses the same rule after the fact — grouping by artist+album, lossless never counted worse than lossy.</span></span>
+        </summary>
+        <div style="margin-top:0.6rem;">
+          <div class="alert alert-yellow">Always preview first — delete buttons are red and secondary.</div>
+          <div class="btn-row">
+            <button class="btn btn-primary" onclick="scanDuplicates()"><span>Scan for duplicates</span></button>
+          </div>
+          <div class="lib-count" id="dup-count"></div>
+          <div id="dup-results"></div>
+          <div class="alert alert-red" style="font-size:10px;">Deleting with "also remove files" removes them permanently. Preview each group before deleting.</div>
         </div>
-        <div class="alert alert-yellow">Always preview first — delete buttons are red and secondary.</div>
-        <div class="btn-row">
-          <button class="btn btn-primary" onclick="scanDuplicates()"><span>Scan for duplicates</span></button>
+      </details>
+      <details class="section">
+        <summary class="section-title">Cover art</summary>
+        <div style="margin-top:0.6rem;">
+          <div class="field"><label>Query (whole library if empty)</label><input type="text" id="art-query" placeholder="albumartist:Burial"></div>
+          <div class="btn-row">
+            <button class="btn btn-primary" onclick="startArtwork('fetch')">Fetch art <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Checks the album folder first (cover.jpg, folder.jpg, front.jpg), then whichever web sources your config enables. Albums that already have art are skipped unless you tick Re-fetch.</span></span></button>
+            <button class="btn" onclick="startArtwork('embed')">Embed art</button>
+            <label class="check-item"><input type="checkbox" id="art-force"><span>Re-fetch albums that already have art</span></label>
+          </div>
+          <div id="artwork-job"></div>
         </div>
-        <div class="lib-count" id="dup-count"></div>
-        <div id="dup-results"></div>
-        <div class="alert alert-red" style="font-size:10px;">Deleting with "also remove files" removes them permanently. Preview each group before deleting.</div>
-      </div>
-      <div class="section">
-        <div class="section-title">Cover art</div>
-        <div class="field"><label>Query (whole library if empty)</label><input type="text" id="art-query" placeholder="albumartist:Burial"></div>
-        <div class="btn-row">
-          <button class="btn btn-primary" onclick="startArtwork('fetch')">Fetch art <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Checks the album folder first (cover.jpg, folder.jpg, front.jpg), then whichever web sources your config enables. Albums that already have art are skipped unless you tick Re-fetch.</span></span></button>
-          <button class="btn" onclick="startArtwork('embed')">Embed art</button>
-          <label class="check-item"><input type="checkbox" id="art-force"><span>Re-fetch albums that already have art</span></label>
+      </details>
+      <details class="section">
+        <summary class="section-title">Metadata</summary>
+        <div style="margin-top:0.6rem;">
+          <div class="field-row">
+            <div class="field"><label>Field</label><input type="text" list="beet-fields" id="mod-field" placeholder="Loading fields…" autocomplete="off"><datalist id="beet-fields"></datalist></div>
+            <div class="field"><label>New value</label><input type="text" id="mod-value" placeholder="Burial"></div>
+            <div class="field"><label>Query</label><input type="text" id="mod-query" placeholder="album:Untrue"></div>
+          </div>
+          <div class="btn-row">
+            <button class="btn btn-primary" onclick="previewModify()"><span>Preview changes</span></button>
+          </div>
+          <div id="mod-results"></div>
+          <hr class="divider">
+          <div class="field"><label>Query (all fields if empty)</label><input type="text" id="maint-query" placeholder="album:Untrue"></div>
+          <div class="btn-row">
+            <button class="btn btn-primary" onclick="runUpdate()">Check for changes on disk</button>
+            <button class="btn btn-primary" onclick="runWrite()">Check tags to write</button>
+          </div>
+          <div class="btn-row">
+            <button class="btn" onclick="startSync('mbsync')">mbsync <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Network call per track/album — can be slow on a real library.</span></span></button>
+            <button class="btn" onclick="startSync('bpsync')">bpsync</button>
+            <button class="btn" onclick="showMissing()">missing</button>
+          </div>
+          <div id="sync-job"></div>
+          <div id="maint-results"></div>
         </div>
-        <div id="artwork-job"></div>
-      </div>
-      <div class="section">
-        <div class="section-title">Metadata</div>
-        <div class="field-row">
-          <div class="field"><label>Field</label><input type="text" list="beet-fields" id="mod-field" placeholder="Loading fields…" autocomplete="off"><datalist id="beet-fields"></datalist></div>
-          <div class="field"><label>New value</label><input type="text" id="mod-value" placeholder="Burial"></div>
-          <div class="field"><label>Query</label><input type="text" id="mod-query" placeholder="album:Untrue"></div>
-        </div>
-        <div class="btn-row">
-          <button class="btn btn-primary" onclick="previewModify()"><span>Preview changes</span></button>
-        </div>
-        <div id="mod-results"></div>
-        <hr class="divider">
-        <div class="field"><label>Query (all fields if empty)</label><input type="text" id="maint-query" placeholder="album:Untrue"></div>
-        <div class="btn-row">
-          <button class="btn btn-primary" onclick="runUpdate()">Check for changes on disk</button>
-          <button class="btn btn-primary" onclick="runWrite()">Check tags to write</button>
-        </div>
-        <div class="btn-row">
-          <button class="btn" onclick="startSync('mbsync')">mbsync <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Network call per track/album — can be slow on a real library.</span></span></button>
-          <button class="btn" onclick="startSync('bpsync')">bpsync</button>
-          <button class="btn" onclick="showMissing()">missing</button>
-        </div>
-        <div id="sync-job"></div>
-        <div id="maint-results"></div>
-      </div>
+      </details>
 
       <details class="section">
         <summary class="section-title">Formats</summary>

--- a/libops.py
+++ b/libops.py
@@ -77,7 +77,13 @@ def _resolve_field(field):
     """
     if field in PROTECTED_FIELDS:
         raise UserError(f'{field} is not an editable metadata field')
-    return maybe_replace_legacy_field(field, False, modify=True)
+    field = maybe_replace_legacy_field(field, False, modify=True)
+    # Anything else lands as a flexible attribute that write() silently
+    # never writes to the file (the genre/genres class of bug — see
+    # module docstring). Reject it here instead of letting it hide.
+    if field not in library.Item.all_keys():
+        raise UserError(f'{field} is not a known metadata field')
+    return field
 
 
 def _capture(fn, *args, **kwargs):

--- a/test_libops.py
+++ b/test_libops.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Unit test for #61: /library/modify rejects unknown fields.
+
+The datalist input that replaced the field <select> is free text again —
+exactly the hazard the dropdown had closed. Before this, an unknown field
+name landed as a beets flexible attribute that never reached the file (the
+genre/genres bug, hidden for four releases). _resolve_field() must now
+reject anything outside beets' known field list, and it must do so before
+ever touching the library — proven here by making get_library() explode if
+reached, rather than just asserting the (still-empty) result.
+
+Run: ~/.local/pipx/venvs/beets/bin/python test_libops.py
+"""
+from beets.ui import UserError
+
+import libops
+
+
+def main():
+    libops.get_library = lambda: (_ for _ in ()).throw(
+        AssertionError('should not reach the library'))
+
+    for fn in (libops.preview_modify, libops.apply_modify):
+        try:
+            fn('not_a_real_field', 'x', '')
+            assert False, f'{fn.__name__} should have rejected an unknown field'
+        except UserError as e:
+            assert 'not_a_real_field' in str(e), e
+
+    # A real field passes validation and falls through to the library call
+    # (proven by the patched get_library() firing, not a silent pass).
+    try:
+        libops.apply_modify('artist', 'x', '')
+        assert False, 'expected get_library() to be reached for a real field'
+    except AssertionError as e:
+        assert 'should not reach' in str(e)
+
+    # The legacy singular->plural translation runs before the reject check.
+    try:
+        libops.apply_modify('genre', 'x', '')
+        assert False, 'expected get_library() to be reached for genre->genres'
+    except AssertionError as e:
+        assert 'should not reach' in str(e)
+
+    # Still-protected fields keep their own, more specific message.
+    try:
+        libops.apply_modify('path', 'x', '')
+        assert False, 'path should still be rejected'
+    except UserError as e:
+        assert 'editable metadata field' in str(e), e
+
+    print('ok')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Closes #61

## Summary
- `mod-field` (Metadata → Field) and `lib-sort` (Library → Sort by) are now `<input list>` + `<datalist>` instead of `<select>`, populated from `/info/fields` — a 2-3 character substring match finds any of beets' ~100 fields instead of scrolling a flat "other fields" optgroup.
- Because the field input is free text again, `libops._resolve_field()` now rejects any field name outside beets' known field list (`library.Item.all_keys()`, the same set `/info/fields` serves) with a 400 — closing the genre/genres-class hazard (unknown field silently lands as a flexible attribute, never reaches the file) before it could reopen.
- Library sort dropdown's known-column safety was already handled server-side (`_order_by()`/`_resolve_sort()` validate against the live schema and fall back), so no backend change was needed there.

## Test plan
- [x] `~/.local/pipx/venvs/beets/bin/python test_libops.py` — unit test proving unknown/protected fields are rejected before the library is ever touched, and that legacy `genre`→`genres` translation still runs first
- [x] `python -c "import server"` — sanity import, no syntax/wiring errors
- [x] Manual load of `beetsgui.html` in browser preview — no console errors from the new markup/JS