### PR TITLE
Name sections after intent, not after beets commands (#66)

### DIFF
--- a/beetsgui.html
+++ b/beetsgui.html
@@ -500,9 +500,9 @@
             <button class="btn btn-primary" onclick="runWrite()">Check tags to write</button>
           </div>
           <div class="btn-row">
-            <button class="btn" onclick="startSync('mbsync')">mbsync <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Network call per track/album — can be slow on a real library.</span></span></button>
-            <button class="btn" onclick="startSync('bpsync')">bpsync</button>
-            <button class="btn" onclick="showMissing()">missing</button>
+            <button class="btn" onclick="startSync('mbsync')">Re-fetch from MusicBrainz <span class="mono">(mbsync)</span> <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Network call per track/album — can be slow on a real library.</span></span></button>
+            <button class="btn" onclick="startSync('bpsync')">Re-fetch from Beatport <span class="mono">(bpsync)</span></button>
+            <button class="btn" onclick="showMissing()">Find tracks missing from albums <span class="mono">(missing)</span></button>
           </div>
         </div>
       </details>


### PR DESCRIPTION
## Summary
- The three leaked beets subcommand names in Library's Metadata section — `mbsync`, `bpsync`, `missing` — become "Re-fetch from MusicBrainz", "Re-fetch from Beatport", "Find tracks missing from albums", with the beets term kept as a small `(mbsync)`-style parenthetical so existing knowledge still transfers.
- Everything else audited and deliberately left alone: "Check for changes on disk"/"Check tags to write" (the issue itself calls these good), the Inbox import form's handling/incremental/singleton labels (already plain-language from an earlier phase), and Preferences' plugin checkboxes + the Command section's raw `beet ls`/`-f` builder (deliberately technical surfaces, same boundary #65 drew around `#prefs-version-results`).
- Copy-only change — no logic touched.

## Test plan
- [x] Full suite (`test_jobs`, `test_scope`, `test_libops`, `test_filter`, `test_playback`, `test_traktor`, `test_importsession`, `test_transcode`) passes unchanged
- [x] Manually verified in-browser: renamed buttons render correctly, `showMissing()` still works end-to-end through #65's shared result panel, no console errors

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)