### PR TITLE
Square splash logo, LaunchAgent for server autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,31 @@ With http://localhost:1612 open in Safari:
 
 The server will now open the standalone app automatically on next launch.
 
-### 4. Create a launcher (Automator)
+### 4. Keep the server running
 
-Open **Automator → New → Application → Run Shell Script**:
+The Safari Web App has no code of its own to start the server — it's just a
+bookmark-like shortcut to `http://localhost:1612/`. Something else has to
+have the server up before you click it.
+
+**Option A — LaunchAgent (recommended):** starts the server at login and
+keeps it running, restarting it if it ever crashes. No separate app to
+click, ever.
+
+```bash
+./scripts/install-launchagent.sh
+```
+
+Logs land at `~/Library/Logs/beetsgui-server.log`. To undo:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.beetsgui.server.plist
+rm ~/Library/LaunchAgents/com.beetsgui.server.plist
+```
+
+**Option B — Automator launcher:** if you'd rather start the server
+manually each time (e.g. it only makes sense running while an external
+drive holding your library is mounted), open **Automator → New →
+Application → Run Shell Script**:
 
 ```bash
 /path/to/python server.py

--- a/beetsgui.html
+++ b/beetsgui.html
@@ -219,7 +219,7 @@
   .badge { font-size:9px; letter-spacing:0.06em; text-transform:uppercase; background:var(--bg3); border:1px solid var(--border2); border-radius:3px; color:var(--text3); padding:1px 5px; vertical-align:middle; }
   .badge-rec { background:var(--green-bg); border-color:var(--green); color:var(--green); }
   #splash { position:fixed;inset:0;background:var(--bg);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:1.2rem;z-index:9999;transition:opacity 0.45s ease; }
-  #splash img { width:96px;height:96px;border-radius:20px;box-shadow:0 4px 24px rgba(0,0,0,0.4); }
+  #splash img { width:96px;height:96px;box-shadow:0 4px 24px rgba(0,0,0,0.4); }
   #splash .splash-title { font-size:18px;font-weight:700;letter-spacing:0.16em;text-transform:uppercase;color:var(--accent); }
 </style>
 </head>

--- a/scripts/install-launchagent.sh
+++ b/scripts/install-launchagent.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Installs a LaunchAgent that starts the beetsGUI server at login and keeps
+# it running (restarts it if it crashes) — so it's already up by the time
+# you click the Safari Web App icon, no separate "Launcher.app" click needed.
+#
+# Run once: ./scripts/install-launchagent.sh
+# Undo:     launchctl unload ~/Library/LaunchAgents/com.beetsgui.server.plist
+#           rm ~/Library/LaunchAgents/com.beetsgui.server.plist
+set -e
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LABEL="com.beetsgui.server"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+LOG_DIR="$HOME/Library/Logs"
+
+# Prefer the pipx beets venv (has Flask injected per the README), fall back
+# to plain python3 on PATH.
+if [ -x "$HOME/.local/pipx/venvs/beets/bin/python" ]; then
+  PYTHON="$HOME/.local/pipx/venvs/beets/bin/python"
+else
+  PYTHON="$(command -v python3)"
+fi
+"$PYTHON" -c "import flask" 2>/dev/null || {
+  echo "error: $PYTHON has no Flask. Run: pipx inject beets flask" >&2
+  exit 1
+}
+
+mkdir -p "$LOG_DIR"
+
+cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$PYTHON</string>
+    <string>$REPO_DIR/server.py</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>$REPO_DIR</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>$LOG_DIR/beetsgui-server.log</string>
+  <key>StandardErrorPath</key>
+  <string>$LOG_DIR/beetsgui-server.log</string>
+</dict>
+</plist>
+EOF
+
+launchctl unload "$PLIST" 2>/dev/null || true
+launchctl load -w "$PLIST"
+
+echo "Installed. Server will start at login and stay running — logs at $LOG_DIR/beetsgui-server.log"
+echo "Starting it now for this session too..."
+sleep 1
+curl -s "http://localhost:${BEETSGUI_PORT:-1612}/" >/dev/null && echo "Server is up." || echo "Not responding yet — check the log."


### PR DESCRIPTION
## Summary
- Splash screen's logo is no longer rounded — `border-radius:20px` was cutting the corners off a square logo.
- New `scripts/install-launchagent.sh`: installs a LaunchAgent that starts the server at login and keeps it running (restarts on crash), so it's already up whenever the Safari Web App is opened. No more needing to remember to click a separate Launcher.app first.
- README documents it as Option A under a new "4. Keep the server running" section; the existing Automator launcher is kept as Option B for anyone who wants to start it manually (e.g. only while an external library drive is mounted).

## Test plan
- [x] Existing test suite passes unchanged (no server/client logic touched, only CSS + docs + a new standalone shell script)
- [x] Verified live: killed the old manually-started server, ran the install script, confirmed `launchctl list` shows the job, confirmed the server came up and served the real library (2560 albums) at `/library`, confirmed the log file at `~/Library/Logs/beetsgui-server.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)