### PR TITLE
Resolve relative item/album paths instead of misreporting them as decoder gaps (#78)

### DIFF
--- a/beetsgui.html
+++ b/beetsgui.html
@@ -2049,8 +2049,20 @@ function playAt(i){queueIdx=i;playCurrent();}
 function playCurrent(){
   const a=document.getElementById('player-audio'),t=queue[queueIdx];
   if(!t)return stopPlayback();
-  a.src='/stream/'+t.id;
-  a.play().catch(()=>{});  // a failed load reports itself through the error event
+  const url='/stream/'+t.id;
+  // A tiny ranged check before handing the URL to <audio>: its error event
+  // carries a generic MediaError code, not the server's actual reason, so a
+  // 404 ("file is missing from disk") used to get reported as "no decoder"
+  // — true for a codec gap, misleading for everything else. A genuine decode
+  // failure still reaches <audio>'s own 'error' listener below unchanged.
+  fetch(url,{headers:{Range:'bytes=0-0'}}).then(r=>{
+    if(r.ok){ a.src=url; a.play().catch(()=>{}); return; }
+    return r.json().catch(()=>({})).then(d=>{
+      const m=document.getElementById('player-meta');
+      m.className='player-meta err';
+      m.textContent='Cannot play this '+(t.format||'file')+' — '+(d.error||('HTTP '+r.status));
+    });
+  });
   setNowPlaying(t);
   renderPlayer();
 }

--- a/server.py
+++ b/server.py
@@ -203,6 +203,37 @@ def get_library_db_path() -> str:
     return os.path.expanduser('~/.config/beets/library.db')
 
 
+@functools.lru_cache(maxsize=1)
+def get_library_directory() -> str:
+    """The beets `directory:` key from config.yaml — same parse as
+    get_library_db_path(), same cache lifetime assumption."""
+    config_path = get_config_path()
+    try:
+        for line in Path(config_path).read_text().splitlines():
+            m = re.match(r'^directory:\s*(.+)$', line.strip())
+            if m:
+                return os.path.expanduser(m.group(1).strip().strip('\'"'))
+    except Exception:
+        pass
+    return os.path.expanduser('~/Music')
+
+
+def resolve_item_path(raw) -> str:
+    """Decode a path column (items.path / albums.artpath) to an absolute path.
+
+    beets always stores absolute paths — that's supposed to be true by
+    construction. This library's data doesn't hold that invariant for most
+    rows (relative paths, cause not yet root-caused — see beetsGUI#78), so
+    every route that turns a stored path into a real filesystem path goes
+    through here rather than assuming the column is already absolute.
+    """
+    path = os.fsdecode(raw) if isinstance(raw, bytes) else raw
+    if not path:
+        return ''
+    if os.path.isabs(path):
+        return path
+    return os.path.join(get_library_directory(), path)
+
 
 def open_app_when_ready():
     """Open the Safari Web App (or Safari) once the server is ready."""
@@ -388,8 +419,7 @@ def library_tracks():
         tracks = []
         for r in rows:
             t = dict(r)
-            # beets stores paths as BLOBs of raw filesystem bytes.
-            t['path'] = os.fsdecode(t['path']) if t['path'] else ''
+            t['path'] = resolve_item_path(t['path'])
             tracks.append(t)
         return jsonify({'ok': True, 'tracks': tracks, 'total': total})
     except sqlite3.Error as e:
@@ -454,8 +484,7 @@ def stream(item_id):
     if not row:
         return jsonify({'ok': False, 'error': 'no such track'}), 404
 
-    # beets stores paths as BLOBs of raw filesystem bytes.
-    path = os.fsdecode(row['path'])
+    path = resolve_item_path(row['path'])
     if not os.path.isfile(path):
         return jsonify({'ok': False, 'error': 'file is missing from disk'}), 404
     return send_file(path, conditional=True,
@@ -477,7 +506,7 @@ def reveal(item_id):
     con.close()
     if not row:
         return jsonify({'ok': False, 'error': 'no such track'}), 404
-    path = os.fsdecode(row['path'])
+    path = resolve_item_path(row['path'])
     if not os.path.isfile(path):
         return jsonify({'ok': False, 'error': 'file is missing from disk'}), 404
     subprocess.run(['open', '-R', path], check=False)
@@ -496,7 +525,7 @@ def album_art(album_id):
     con.close()
     if not row or not row['artpath']:
         return jsonify({'ok': False, 'error': 'no art'}), 404
-    path = os.fsdecode(row['artpath'])
+    path = resolve_item_path(row['artpath'])
     if not os.path.isfile(path):
         return jsonify({'ok': False, 'error': 'art file is missing from disk'}), 404
     return send_file(path, conditional=True)

--- a/test_playback.py
+++ b/test_playback.py
@@ -205,6 +205,42 @@ def main():
     assert get('/stream/1').status_code == 404
     assert get('/art/1').status_code == 404
 
+    # ── relative paths (beetsGUI#78) ────────────────────────────────────────
+    # This user's library has items.path/albums.artpath stored relative
+    # rather than absolute (root cause not yet found) — /stream and /art
+    # must resolve them against `directory:` rather than assume they're
+    # already absolute, or every one of those rows 404s as "missing from
+    # disk" and the player blames it on "no decoder" instead.
+    rel_tmp = tempfile.TemporaryDirectory()
+    rel_root = Path(rel_tmp.name)
+    (rel_root / 'sub').mkdir()
+    rel_audio = rel_root / 'sub' / 'archangel.wav'
+    make_wav(rel_audio)
+    rel_art = rel_root / 'sub' / 'cover.jpg'
+    rel_art.write_bytes(b'\xff\xd8\xff\xe0fake jpeg')
+    rel_db = rel_root / 'rel-library.db'
+    con = sqlite3.connect(rel_db)
+    con.executescript('''
+        CREATE TABLE albums (id INTEGER PRIMARY KEY, artpath BLOB);
+        CREATE TABLE items (id INTEGER PRIMARY KEY, path BLOB);
+    ''')
+    con.execute('INSERT INTO albums VALUES (1,?)', (b'sub/cover.jpg',))
+    con.execute('INSERT INTO items VALUES (1,?)', (b'sub/archangel.wav',))
+    con.commit()
+    con.close()
+
+    server.get_library_db_path = lambda: str(rel_db)
+    server.get_library_directory = lambda: str(rel_root)
+
+    r = get('/stream/1')
+    assert r.status_code == 200, r.status_code
+    assert r.data == rel_audio.read_bytes(), 'relative item path did not resolve'
+
+    r = get('/art/1')
+    assert r.status_code == 200, r.status_code
+    assert r.data == rel_art.read_bytes(), 'relative artpath did not resolve'
+
+    rel_tmp.cleanup()
     tmp.cleanup()
     print('test_playback: all checks passed')
 


### PR DESCRIPTION
## Summary
- Root cause of "Cannot play this MP3 — no decoder": not a codec problem. ~97% of `items.path`/`albums.artpath` rows in this library are stored **relative**, not absolute (why, tracked separately in #78). `/stream`, `/art`, `/reveal` all did `os.path.isfile()` on the raw stored value, so every relative row 404'd as "missing from disk" regardless of format.
- `resolve_item_path()` in `server.py` joins a relative path against `get_library_directory()` (parses `directory:` from `config.yaml`, same pattern as the existing `get_library_db_path()`) before touching the filesystem. Applied everywhere a stored path reaches disk: `/stream`, `/art`, `/reveal`, and the track list's `path` field (used by Copy path).
- Client-side: `playCurrent()` now does a cheap ranged check before handing the URL to `<audio>`, so an HTTP-level failure (file missing, no library, etc.) shows the server's real error text instead of always claiming "no decoder for it in this browser." Genuine decode failures still go through the existing `error` listener unchanged.

## Test plan
- [x] New regression case in `test_playback.py`: a relative `items.path` and `albums.artpath` against a synthetic library, asserting `/stream` and `/art` both resolve and serve correctly
- [x] Full existing suite passes unchanged
- [x] Verified against the real library: `/stream/1344` (an MP3 with a relative path) went from `404 "file is missing from disk"` to `206 Partial Content, audio/mpeg`; same for an AIFF track (`/stream/1872` → `206, audio/x-aiff`); `/art/78` (relative artpath) went from 404 to `200, image/jpeg`. Confirmed a genuinely-unmounted-drive track (`/stream/242`, on a different, not-currently-mounted volume) still correctly 404s — the fix doesn't paper over real missing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)