### PR TITLE
Rebuild USB Mirror as a real playlist-scoped convert job (#43)

### DIFF
--- a/beetsgui.html
+++ b/beetsgui.html
@@ -574,9 +574,26 @@
   formats:
     alac:
       command: ffmpeg -i $source -c:a alac -map_metadata 0 $dest
-      extension: m4a</pre>
+      extension: m4a
+    mp3_320:
+      command: ffmpeg -i $source -y -vn -c:a libmp3lame -b:a 320k $dest
+      extension: mp3</pre>
+            <div style="margin-top:0.3rem;">"format" above is only the config default — the dropdown below overrides it per run, for any format you pick.</div>
           </div>
           <div class="lib-count scope-line"></div>
+          <div class="field"><label>Format (blank = convert.format from config)</label>
+            <select id="beet-conv-fmt" style="width:auto;">
+              <option value="">config default</option>
+              <option value="alac">ALAC (lossless)</option>
+              <option value="flac">FLAC (lossless)</option>
+              <option value="mp3_320">MP3 320kbps (LAME)</option>
+              <option value="mp3">MP3 VBR ~190</option>
+              <option value="aac">AAC 256kbps</option>
+              <option value="opus">Opus 96kbps</option>
+              <option value="ogg">Ogg Vorbis</option>
+              <option value="wma">WMA</option>
+            </select>
+          </div>
           <div class="field"><label>Destination (blank = convert.dest from config)</label><input type="text" id="beet-conv-dest" placeholder="~/Music/Converted"></div>
           <div class="btn-row">
             <button class="btn btn-primary" onclick="startConvert()">Check what would convert</button>
@@ -633,15 +650,46 @@
         <div class="alert alert-yellow" style="font-size:10px;">1. In Traktor: Right-click <b>Track Collection</b> → <b>Check Consistency</b><br>2. Select ALL missing tracks (<b>Cmd+A</b>)<br>3. Click <b>Relocate</b> → navigate to your Beets library folder<br>4. ⚠ Select multiple files at a time — avoids Traktor 4.2 freeze<br>5. Cues and grids follow automatically</div>
       </div>
       <div class="section">
-        <div class="section-title">Playlists on this Mac (USB mirror)</div>
+        <div class="section-title">USB Mirror<span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Mirrors the library to a USB drive as MP3/AAC using beets' own convert plugin. Run again — already-converted tracks are skipped, so only new ones get copied.</span></span></div>
+        <div class="field">
+          <label>Destination (USB drive)</label>
+          <div class="field-row">
+            <div class="field" style="margin-bottom:0"><input type="text" id="usb-dest" placeholder="/Volumes/USB"></div>
+            <button class="btn btn-sm" onclick="promptVolume('usb-dest')">Volumes/…</button>
+          </div>
+        </div>
+        <div class="field">
+          <label>Format</label>
+          <select id="usb-fmt" style="width:auto;">
+            <option value="mp3_320">MP3 320kbps (LAME)</option>
+            <option value="mp3">MP3 VBR ~190</option>
+            <option value="aac">AAC 256kbps</option>
+            <option value="alac">ALAC (lossless)</option>
+            <option value="flac">FLAC (lossless)</option>
+            <option value="opus">Opus 96kbps</option>
+            <option value="ogg">Ogg Vorbis</option>
+            <option value="wma">WMA</option>
+          </select>
+        </div>
         <div class="field">
           <label>Playlist folder</label>
           <div class="field-row">
-            <div class="field" style="margin-bottom:0"><input type="text" id="usb-dir" placeholder="~/Playlister" value="~/Playlister"></div>
-            <button class="btn btn-sm btn-primary" onclick="listPlaylists()">List playlists</button>
+            <div class="field" style="margin-bottom:0"><input type="text" id="usb-pl-dir" placeholder="~/Playlister" value="~/Playlister"></div>
+            <button class="btn btn-sm" onclick="findUsbPlaylists()">Find playlists</button>
           </div>
         </div>
-        <div class="lib-results" id="usb-results"></div>
+        <div id="usb-pl-panel" style="display:none;margin-bottom:0.75rem;">
+          <div class="section-title" style="margin-bottom:0.4rem;">Select playlists</div>
+          <div class="check-group" id="usb-pl-list"></div>
+          <label class="check-item" style="margin-top:0.5rem;">
+            <input type="checkbox" id="usb-all" checked onchange="toggleUsbAll(this)">
+            <span>Entire library (no filter)</span>
+          </label>
+        </div>
+        <div class="btn-row">
+          <button class="btn btn-primary" onclick="startUsbSync()">Check what would sync</button>
+        </div>
+        <div class="alert alert-yellow" style="font-size:10px;margin-top:0.5rem;">Requires the <span class="mono">convert</span> plugin and <span class="mono">ffmpeg</span> — enable convert in Preferences → Plugins. Playlist scoping reads the .m3u directly (no <span class="mono">playlist</span> plugin needed).</div>
       </div>
     </div>
 
@@ -2541,8 +2589,9 @@ function countFormats(exts){
 let pendingConvert=null;
 function startConvert(){
   const dest=document.getElementById('beet-conv-dest').value.trim();
-  pendingConvert={dest:dest||null,scope:scopeBody()};
-  startJob('/convert/start',{pretend:true,dest:pendingConvert.dest,...pendingConvert.scope},
+  const fmt=document.getElementById('beet-conv-fmt').value;
+  pendingConvert={dest:dest||null,format:fmt||null,scope:scopeBody()};
+  startJob('/convert/start',{pretend:true,dest:pendingConvert.dest,format:pendingConvert.format,...pendingConvert.scope},
     (ev,el)=>{
       if(!ev.total)return;
       el.innerHTML+='<div class="btn-row"><button class="btn btn-warn btn-sm" onclick="runConvert()">Convert '+
@@ -2551,7 +2600,7 @@ function startConvert(){
 }
 function runConvert(){
   if(!pendingConvert)return;
-  startJob('/convert/start',{pretend:false,dest:pendingConvert.dest,...pendingConvert.scope});
+  startJob('/convert/start',{pretend:false,dest:pendingConvert.dest,format:pendingConvert.format,...pendingConvert.scope});
 }
 // Server gives up on a scan after a wall-clock budget (#35) rather than
 // running forever on a huge dir — say so, or a partial count/list quietly
@@ -2648,18 +2697,59 @@ function useForImport(path){
   document.getElementById('import-setup').scrollIntoView({behavior:'smooth',block:'start'});
 }
 
-function listPlaylists(){
-  const dir=document.getElementById('usb-dir').value.trim()||'~/Playlister';
-  const el=document.getElementById('usb-results');
-  el.innerHTML='<div class="lib-empty">Loading…</div>';
+function findUsbPlaylists(){
+  const dir=document.getElementById('usb-pl-dir').value.trim()||'~/Playlister';
+  const panel=document.getElementById('usb-pl-panel');
+  const list=document.getElementById('usb-pl-list');
   fetch('/playlists?dir='+encodeURIComponent(dir))
     .then(r=>r.json())
     .then(data=>{
-      if(!data.ok){el.innerHTML='<div class="lib-empty">'+escapeHtml(data.error||'Could not read that folder.')+'</div>';return;}
-      if(!data.playlists.length){el.innerHTML='<div class="lib-empty">No .m3u playlists found in '+escapeHtml(data.dir)+'.</div>';return;}
-      el.innerHTML=data.playlists.map(p=>'<div class="lib-row"><div class="lib-row-title">'+escapeHtml(p)+'.m3u</div></div>').join('');
+      if(!data.ok){list.innerHTML='<div class="lib-empty">'+escapeHtml(data.error||'Could not read that folder.')+'</div>';}
+      else if(!data.playlists.length){list.innerHTML='<div class="lib-empty">No .m3u playlists found in '+escapeHtml(data.dir)+'.</div>';}
+      else list.innerHTML=data.playlists.map(p=>
+        '<label class="check-item"><input type="checkbox" class="usb-pl" value="'+escapeHtml(p)+'" onchange="document.getElementById(\'usb-all\').checked=false"> '+escapeHtml(p)+'</label>').join('');
+      panel.style.display='block';
     })
-    .catch(()=>{el.innerHTML='<div class="lib-empty">Could not reach the server.</div>';});
+    .catch(()=>{list.innerHTML='<div class="lib-empty">Could not reach the server.</div>';panel.style.display='block';});
+}
+function toggleUsbAll(cb){
+  if(cb.checked)document.querySelectorAll('.usb-pl').forEach(el=>{el.checked=false});
+}
+// Resolves selected playlists to a {scope:{ids:[...]}} body — NOT a
+// playlist:name query. beets' own `playlist` plugin builds absolute paths
+// and matches them with a plain InQuery, which never normalizes for the
+// beets 2.11 relative-path migration, so playlist:name matches nothing
+// against a library with `directory:` set. /playlists/resolve reads the
+// .m3u itself and resolves it with the (normalizing) path query instead
+// — see libops.playlist_item_ids.
+function usbScope(){
+  if(document.getElementById('usb-all').checked)return Promise.resolve({});
+  const selected=Array.from(document.querySelectorAll('.usb-pl:checked')).map(c=>c.value);
+  if(!selected.length)return Promise.resolve({});
+  return postJSON('/playlists/resolve',{dir:document.getElementById('usb-pl-dir').value.trim()||'~/Playlister',names:selected})
+    .then(data=>{
+      if(!data.ok)throw new Error(data.error||'Could not resolve playlist.');
+      if(!data.ids.length)throw new Error('Selected playlist(s) matched no tracks in the library.');
+      return {scope:{ids:data.ids}};
+    });
+}
+let pendingUsbSync=null;
+function startUsbSync(){
+  const dest=document.getElementById('usb-dest').value.trim();
+  if(!dest){renderResult('<div class="lib-empty">Enter a USB destination path first.</div>');return;}
+  usbScope().then(scope=>{
+    pendingUsbSync={dest,format:document.getElementById('usb-fmt').value,scope};
+    startJob('/convert/start',{pretend:true,dest:pendingUsbSync.dest,format:pendingUsbSync.format,...pendingUsbSync.scope},
+      (ev,el)=>{
+        if(!ev.total)return;
+        el.innerHTML+='<div class="btn-row"><button class="btn btn-warn btn-sm" onclick="runUsbSync()">Sync '+
+          ev.total+' track'+(ev.total===1?'':'s')+' to USB</button></div>';
+      });
+  }).catch(e=>renderResult('<div class="lib-empty">'+escapeHtml(e.message)+'</div>'));
+}
+function runUsbSync(){
+  if(!pendingUsbSync)return;
+  startJob('/convert/start',{pretend:false,dest:pendingUsbSync.dest,format:pendingUsbSync.format,...pendingUsbSync.scope});
 }
 
 function updatePathPreview(){
@@ -2694,7 +2784,7 @@ function buildConfig(){
   if(plugins.includes('embedart'))y+='embedart:\n  auto: yes\n  if_empty: yes\n\n';
   if(plugins.includes('chroma'))y+='chroma:\n  auto: yes\n\n';
   if(plugins.includes('lastgenre'))y+='lastgenre:\n  auto: yes\n  source: album\n  count: 1\n  min_weight: 10\n  fallback: Electronic\n\n';
-  if(plugins.includes('convert'))y+='convert:\n  format: alac\n  never_convert_lossy_files: yes\n  formats:\n    alac:\n      command: ffmpeg -i $source -c:a alac -map_metadata 0 $dest\n      extension: m4a\n\n';
+  if(plugins.includes('convert'))y+='convert:\n  format: alac\n  never_convert_lossy_files: yes\n  formats:\n    alac:\n      command: ffmpeg -i $source -c:a alac -map_metadata 0 $dest\n      extension: m4a\n    mp3_320:\n      command: ffmpeg -i $source -y -vn -c:a libmp3lame -b:a 320k $dest\n      extension: mp3\n\n';
   if(plugins.includes('musicbrainz')){y+='musicbrainz:\n  data_source_mismatch_penalty: 0.4\n';if(mbUser)y+='  user: "'+mbUser+'"\n';if(mbPass)y+='  pass: "'+mbPass+'"\n';y+='\n';}
   if(plugins.includes('discogs')){y+='discogs:\n  data_source_mismatch_penalty: 0.5\n';if(discogsMethod==='token'&&discogsToken)y+='  user_token: "'+discogsToken+'"\n';y+='\n';}
   if(plugins.includes('beatport4')){y+='beatport4:\n';if(bp4Method==='userpass'&&bp4User){y+='  username: "'+bp4User+'"\n';if(bp4Pass)y+='  password: "'+bp4Pass+'"\n';}y+='  art: '+(bp4Art?'yes':'no')+'\n  data_source_mismatch_penalty: '+bp4Prio+'\n\n';}

--- a/libops.py
+++ b/libops.py
@@ -10,15 +10,18 @@ confirm), so remove gets its own preview step here instead; same for
 modify, which beets only exposes via its interactive `modify_items`.
 """
 import io
+import os
 import re
 import shlex
 import threading
 from contextlib import redirect_stdout
+from pathlib import Path
 
 from platform import python_version
 
 import beets
 from beets import library, plugins
+from beets.dbcore.query import OrQuery, PathQuery
 from beets.ui import UserError
 from beets.ui.commands.remove import remove_items as _remove_items
 from beets.ui.commands.update import update_items as _update_items
@@ -302,6 +305,40 @@ def missing_albums():
                 'album': album.album, 'have': have, 'total': total,
             })
     return result
+
+
+# ── playlist scoping (#43) ──────────────────────────────────────────────
+# beets' own `playlist` plugin (playlist:name queries) can't be reused
+# here: PlaylistQuery builds absolute paths and compares them with a plain
+# InQuery, which never calls dbcore.pathutils.normalize_path_for_db — so it
+# silently matches nothing against a library whose paths were migrated to
+# be relative to `directory:` (mandatory since beets 2.11, same migration
+# server.py's resolve_item_path handles on the read side). PathQuery does
+# normalize, so this resolves the .m3u itself and queries by path instead.
+
+def playlist_item_ids(playlist_dir, names):
+    """Item ids listed by one or more .m3u playlists (by stem, under
+    playlist_dir — same files /playlists already lists for the picker).
+
+    Lines are resolved the way beets' own importfeeds plugin writes them:
+    absolute as-is, otherwise relative to the library directory.
+    """
+    lib = get_library()
+    library_dir = beets.config['directory'].as_filename()
+    ids = set()
+    for name in names:
+        m3u = Path(os.path.expanduser(playlist_dir)) / f'{name}.m3u'
+        if not m3u.is_file():
+            raise UserError(f'no such playlist: {name}')
+        lines = [ln.strip() for ln in
+                 m3u.read_text(errors='surrogateescape').splitlines()]
+        paths = [ln if os.path.isabs(ln) else os.path.join(library_dir, ln)
+                 for ln in lines if ln and not ln.startswith('#')]
+        if not paths:
+            continue
+        query = OrQuery([PathQuery('path', p) for p in paths])
+        ids.update(i.id for i in lib.items(query))
+    return sorted(ids)
 
 
 # ── remove ───────────────────────────────────────────────────────────────

--- a/server.py
+++ b/server.py
@@ -940,6 +940,24 @@ def list_playlists():
         return jsonify({'ok': False, 'error': str(e)})
 
 
+@app.route('/playlists/resolve', methods=['POST'])
+def resolve_playlists():
+    """Item ids listed by one or more .m3u playlists — used by USB Mirror
+    (#43) to scope a convert job to a playlist. Body: {"dir": "~/Playlister",
+    "names": ["My Playlist"]}. Not beets' own `playlist:` query — see
+    libops.playlist_item_ids's docstring for why."""
+    data = request.get_json(silent=True) or {}
+    names = data.get('names')
+    if not isinstance(names, list) or not names or not all(
+            isinstance(n, str) and n for n in names):
+        return jsonify({'ok': False, 'error': 'names must be a non-empty list of strings'}), 400
+    try:
+        ids = libops.playlist_item_ids(data.get('dir') or '~/Playlister', names)
+    except UserError as e:
+        return jsonify({'ok': False, 'error': str(e)}), 400
+    return jsonify({'ok': True, 'ids': ids})
+
+
 @app.route('/export/m3u', methods=['POST'])
 def export_m3u():
     """Write matching tracks' paths, one per line, to `dest` — same content

--- a/test_usb_mirror.py
+++ b/test_usb_mirror.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+End-to-end check for the rebuilt USB Mirror feature (#43).
+
+USB Mirror is "point transcode.py's existing convert job at a dest outside
+the library, scoped to a playlist" — so this proves the actual parity
+checklist from the issue rather than re-testing transcode.py itself
+(already covered by test_transcode.py): a custom format (mp3_320/LAME, not
+a convert-plugin builtin), playlist-scoped convert, dry-run writing
+nothing, and a real run being incremental (unchanged on rerun).
+
+Playlist scoping does NOT use beets' own `playlist` plugin — verified
+during implementation that PlaylistQuery never normalizes for the beets
+2.11 relative-path migration (upstream gap), so `playlist:name` matches
+zero items against a library that has directory: set (the normal case).
+/playlists/resolve (libops.playlist_item_ids) reads the .m3u itself and
+resolves it via PathQuery instead, which does normalize.
+
+Run: ~/.local/pipx/venvs/beets/bin/python test_usb_mirror.py
+Needs ffmpeg (with a libmp3lame encoder) to make and convert test audio.
+"""
+import shutil
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import test_importsession as ti
+
+FMT = 'mp3_320'
+
+
+def main():
+    if not shutil.which('ffmpeg'):
+        raise SystemExit('ffmpeg needed to generate test audio — skipping')
+
+    tmp = Path(tempfile.mkdtemp(prefix='beetsgui-usbmirror-test-'))
+    beetsdir = tmp / 'beets'
+    beetsdir.mkdir()
+    plugindir = beetsdir / 'plugins'
+    plugindir.mkdir()
+    (plugindir / 'stubsource.py').write_text(ti.STUB_PLUGIN)
+    dest_dir = tmp / 'usb'
+    playlist_dir = tmp / 'playlists'
+    playlist_dir.mkdir()
+    (beetsdir / 'config.yaml').write_text(
+        f'directory: {tmp / "library"}\n'
+        f'library: {beetsdir / "library.db"}\n'
+        f'pluginpath: [{plugindir}]\n'
+        f'plugins: [stubsource, convert]\n'
+        'import:\n'
+        '    resume: ask\n'
+        '    copy: yes\n'
+        '    write: no\n'
+        'convert:\n'
+        f'    dest: {dest_dir}\n'
+        '    formats:\n'
+        '        mp3_320:\n'
+        '            command: ffmpeg -i $source -y -vn -c:a libmp3lame -b:a 320k $dest\n'
+        '            extension: mp3\n'
+    )
+
+    src = tmp / 'incoming'
+    ti.make_album(src / 'one', 'Mirror Artist', 'Mirror Album', ['Alpha', 'Beta'])
+    ti.make_album(src / 'two', 'Other Artist', 'Other Album', ['Gamma'])
+
+    ti.job[0] = None
+    proc = ti.start_server(beetsdir)
+    try:
+        for path in (src / 'one', src / 'two'):
+            for event in ti.run(path):
+                if event['type'] == 'decision':
+                    ti.decide(event, choice='asis')
+
+        con = sqlite3.connect(beetsdir / 'library.db')
+        rows = con.execute(
+            "SELECT path FROM items WHERE artist = 'Mirror Artist'").fetchall()
+        con.close()
+        assert len(rows) == 2, f'expected 2 imported tracks, got {rows}'
+
+        # Playlist scoping: only "Mirror Artist"'s tracks, library-relative
+        # paths (beets >= 2.11 stores paths under `directory:` that way —
+        # see server.py's resolve_item_path docstring) — the same shape
+        # beets' own importfeeds plugin writes.
+        rel_paths = sorted(p[0].decode() for p in rows)
+        (playlist_dir / 'mirror.m3u').write_text('\n'.join(rel_paths) + '\n')
+
+        status, body = ti.post('/playlists/resolve', {
+            'dir': str(playlist_dir), 'names': ['mirror']})
+        assert status == 200 and body['ok'], body
+        assert len(body['ids']) == 2, f'expected 2 resolved ids: {body}'
+        scope = {'scope': {'ids': body['ids']}}
+
+        # Dry run: reports what would convert, writes nothing.
+        status, body = ti.post('/convert/start', {
+            'format': FMT, 'dest': str(dest_dir), 'pretend': True, **scope})
+        assert status == 200 and body['ok'], body
+        tail = list(ti.events(body['id']))
+        done = tail[-1]
+        assert done['type'] == 'done' and not done.get('aborted'), tail
+        assert done.get('sent') == 2, f'dry run should preview 2 tracks: {done}'
+        assert not list(dest_dir.rglob('*.mp3')), 'dry run wrote files'
+
+        # Real run: converts only the scoped playlist's 2 tracks, not all 3.
+        status, body = ti.post('/convert/start', {
+            'format': FMT, 'dest': str(dest_dir), 'pretend': False, **scope})
+        assert status == 200 and body['ok'], body
+        tail = list(ti.events(body['id']))
+        done = tail[-1]
+        assert done['type'] == 'done' and not done.get('aborted'), tail
+        converted = list(dest_dir.rglob('*.mp3'))
+        assert len(converted) == 2, f'expected 2 converted files, got {converted}'
+        assert all(f.stat().st_size > 0 for f in converted)
+        mtimes = {f: f.stat().st_mtime_ns for f in converted}
+
+        # Incremental: rerunning the same scope re-sends the same tracks to
+        # the converter (transcode.py can't see past that — see its
+        # docstring) but the convert plugin itself must skip re-encoding
+        # ones whose target already exists, so the files are untouched.
+        status, body = ti.post('/convert/start', {
+            'format': FMT, 'dest': str(dest_dir), 'pretend': False, **scope})
+        assert status == 200 and body['ok'], body
+        tail = list(ti.events(body['id']))
+        assert tail[-1]['type'] == 'done' and not tail[-1].get('aborted'), tail
+        assert len(list(dest_dir.rglob('*.mp3'))) == 2, 'rerun added/removed files'
+        for f, mtime in mtimes.items():
+            assert f.stat().st_mtime_ns == mtime, f'{f} was re-encoded on rerun'
+
+        print('ok')
+    finally:
+        ti.stop_server(proc)
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Rebuilds USB Mirror (silently deleted by `ad8cdf7` — see #43 for the git archaeology): destination, format, playlist scoping, and dry-run all wired to the existing `/convert/start` job (`transcode.py`, same pattern #16's ALAC feature uses) — no new backend architecture, no shell composer.
- Playlist scoping bypasses beets' own `playlist` plugin: its `PlaylistQuery` never normalizes for beets 2.11's relative-path migration, so `playlist:name` matches zero items on a normal library (confirmed with an isolated test during implementation). `libops.playlist_item_ids` + new `POST /playlists/resolve` read the `.m3u` directly and resolve it with the (normalizing) `path:` query instead, feeding `/convert/start`'s existing `scope.ids`.
- Adds a real format picker (not ALAC-only) to both USB Mirror and the Preferences "Beets convert" section, and makes the generated `mp3_320` preset use explicit LAME (`-c:a libmp3lame -b:a 320k`).
- A proper XLD-style redesign of these format controls (CBR/VBR, quality sliders, sample rate/bit depth) is scoped separately in #80 — this PR's format `<select>` is an interim, functional stopgap.

## Test plan
- [x] `test_usb_mirror.py` (new) — end-to-end: real ffmpeg conversion + SSE job stream, proving custom format + playlist scoping + dry-run (writes nothing) + incremental rerun (files untouched)
- [x] `test_transcode.py`, `test_libops.py`, `test_importsession.py`, `test_scope.py` — all pass unchanged
- [x] Manually verified in-browser against the real server: USB Mirror section renders, playlist picker populates from a real `~/Playlister`, mutual-exclusion between "entire library" and playlist selection works, format dropdowns render in both places

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)