### PR TITLE
Fix #12 stress-test findings: shell-quoting, apostrophe search, CSRF, stale docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md — beetsGUI
+
+Read this before making changes. It's the essence, not a re-hash — every
+claim here traces to a docstring/comment at the cited location; read that
+for the full reasoning, not this file.
+
+## What this is
+
+Local web app for [beets](https://beets.io) as a Safari Web App on macOS.
+`server.py` (Flask, port 1612) + `beetsgui.html` (single file, no build
+step, no npm). Never assume a build/bundle step exists — there isn't one.
+
+## Non-negotiable safety rule
+
+**Never point a test, a script, or an experiment at `~/.config/beets` or
+`/Volumes`.** The user has a real, live beets library on external drives.
+Every test uses a throwaway `BEETSDIR` in a temp dir — copy the pattern in
+`test_importsession.py`'s `start_server()`/`stop_server()`, don't invent a
+new one. If you need to inspect real files (e.g. to check tags), reading is
+fine; writing/importing/deleting through them is not, without asking.
+
+## Request-boundary security model (#12, #28)
+
+Two `before_request` guards in `server.py`: Host check (`_reject_foreign_host`,
+blocks DNS rebinding) and Origin check (`_reject_foreign_origin`, blocks a
+cross-site page's POST — Host alone doesn't catch this, a cross-site request
+still carries `Host: localhost:<port>`). Both are needed; three separate
+audit passes (#11, #27, #38) treated the Host check plus a "JSON needs a
+preflight" assumption as sufficient, which a `text/plain` body (CORS-safelisted,
+no preflight) defeats. If you add a mutating endpoint, it inherits both
+guards automatically — don't add your own CSRF handling per-route.
+
+No `subprocess` call anywhere uses `shell=True` — every one takes an argv
+list. Keep it that way; string-built shell commands were the root cause the
+old `/run` endpoint got deleted for (see `docs/audit-2026-08-security-review.md`).
+
+## Scope pattern (#63/#64)
+
+Every list/action endpoint takes `{"scope": {"query": "..."}}` or
+`{"scope": {"ids": [...]}}`, never a bare hand-typed query — `libops.scope_query()`
+turns either into the query string `libops.matching_ids()`/`split_query()`
+consume. The Library list and every action share this same resolution path
+on purpose (see `libops.matching_ids()` docstring) — don't add a second way
+to filter that could disagree with it.
+
+## Query building lives in two places that must agree
+
+- Server: `libops.split_query()` — beets' `shlex.split()`, falls back to a
+  plain whitespace split on an unbalanced quote (an apostrophe in a name
+  like `O'Brien` is not an error here, #12).
+- Client: `shellQuote()` in `beetsgui.html` — POSIX single-quotes filter
+  values. This isn't just display: it's the actual query the app sends to
+  `/library*`, and it's also what a user would paste into a real shell if
+  they used the old Command box (deleted #12) or the current filter's raw
+  query box. `test_filter.py` cross-checks both sides against real `bash`
+  and real beets — extend it, don't hand-verify a quoting change.
+
+## Paths in `library.db` can be relative (beets 2.11+)
+
+`resolve_item_path()` in `server.py` handles both forms — since beets
+2.11 (upstream #6460), paths under `directory:` are stored relative to it.
+A relative path is normal, not corruption (#78) — don't "fix" a relative
+path by treating it as a decoder gap or a broken import.
+
+## Job model
+
+`jobs.py`: one beets job at a time, globally — not one-per-type. beets'
+own `config`/`Library` are process-global and not thread-safe for concurrent
+mutation, so import/convert/artwork/sync/Traktor-scan all share one
+single-flight registry. `GET /jobs/current` and `POST /jobs/<id>/abort` are
+shared across every job type, not import-specific — the route names don't
+say "import" despite older docs (including README, before this session)
+sometimes calling them that.
+
+## A trap that already bit once here
+
+Some endpoint URLs in `beetsgui.html` are built by string concatenation
+(e.g. `'/library/'+kind` in `runMaint()`), not written as a literal.
+`git log -S'/library/write'` or a plain grep for the literal route string
+will report "never referenced" even when a real button calls it — this
+produced a wrong dead-code finding in this session's own audit. Trace the
+actual call sites (read the onclick handler through to the fetch/postJSON
+call) before concluding something is unused.
+
+## Testing
+
+11 suites, all `test_*.py` at repo root, each runnable standalone:
+`~/.local/pipx/venvs/beets/bin/python test_<name>.py`. Most need `ffmpeg`
+on PATH. `test_smoke.py` drives a real headless Chromium via Playwright
+(`pipx inject beets playwright && playwright install chromium`) — it's the
+only one that exercises `beetsgui.html`'s actual DOM/JS rather than the
+HTTP API, and it has already caught a bug (a format preset referencing a
+field that doesn't exist) that every API-level test missed. If you touch
+UI behavior, extend this one, not just the API-level tests.
+
+No `fd` or `xld` dependency — both were removed from what the app actually
+calls; don't reintroduce a shell-out to either without a documented reason.

--- a/README.md
+++ b/README.md
@@ -137,8 +137,10 @@ curl -s -X POST localhost:1612/import/<id>/decide -H 'Content-Type: application/
      -d '{"decision_id":"<from the event>","choice":"apply","candidate":0}'
 ```
 
-`POST /import/<id>/abort` cancels cleanly, and `GET /import/current` returns the
-running import plus its waiting decision, so a reloaded page can rejoin.
+`POST /jobs/<id>/abort` cancels cleanly, and `GET /jobs/current` returns the
+running job plus an import's waiting decision, so a reloaded page can rejoin.
+This route is shared across every job type (import, convert, artwork, sync,
+Traktor scan) — not import-specific despite the old name it used to have.
 An unanswered decision times out after 15 minutes (`BEETSGUI_DECISION_TIMEOUT`)
 and aborts the import rather than blocking the server forever.
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ No Electron. No Docker. Just a small Flask server and a single HTML file.
   ```bash
   brew install ffmpeg
   ```
-- [fd](https://github.com/sharkdp/fd) (required for Inbox's Utilities section and Library's Formats/WAV-AIFF finder — the unimported-music scan itself doesn't need it):
-  ```bash
-  brew install fd
-  ```
+
+No `fd` needed: the scans that once shelled out to it (Inbox's Utilities,
+Library's Formats/WAV-AIFF finder) walk the tree in Python instead.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ Test it end to end (needs ffmpeg; runs against a throwaway library):
 ~/.local/pipx/venvs/beets/bin/python test_importsession.py
 ```
 
+`test_smoke.py` drives the real UI in a headless browser against the same
+throwaway-library harness — needs Playwright, once:
+
+```bash
+pipx inject beets playwright
+~/.local/pipx/venvs/beets/bin/playwright install chromium
+~/.local/pipx/venvs/beets/bin/python test_smoke.py
+```
+
 ## DJ workflow notes
 
 - Lossless files (WAV, AIFF, FLAC) convert to **ALAC 24-bit** on import — 32-bit float is handled automatically

--- a/beetsgui.html
+++ b/beetsgui.html
@@ -1617,12 +1617,17 @@ let numericFields=new Set();
 function isNumField(f){return numericFields.has(f);}
 function opsFor(f){return isNumField(f)?FILTER_OPS.num:FILTER_OPS.text;}
 
-// Quote only when beets' shlex split would otherwise break the value apart.
-function quoteVal(v){
-  return /[\s"'\\]/.test(v)?'"'+v.replace(/(["\\])/g,'\\$1')+'"':v;
+// This string is both a beets query and a shell command the user copies, so
+// anything that isn't a plain word is POSIX single-quoted: inside '...' the
+// shell expands nothing, which is what keeps `$artist` a beets template and
+// an artist named `$(id)` an artist name. `'\''` is the standard way to
+// carry an apostrophe through; shlex and splitTokens both unquote it the
+// same way, so the query still round-trips back into the rows.
+function shellQuote(v){
+  return /^[\p{L}\p{N}._\/@=-]+$/u.test(v)?v:"'"+v.replace(/'/g,"'\\''")+"'";
 }
 function filterTerm(r){
-  const v=quoteVal(r.value);
+  const v=shellQuote(r.value);
   if(r.op==='contains')return r.field+':'+v;
   if(r.op==='is')      return r.field+':='+v;
   if(r.op==='isnot')   return '-'+r.field+':='+v;
@@ -1648,7 +1653,8 @@ function splitTokens(s){
       if(c==='\\'&&quote==='"'&&i+1<s.length){cur+=s[++i];continue;}
       if(c===quote){quote=null;continue;}
       cur+=c;
-    } else if(c==='"'||c==="'"){quote=c;quoted=true;}
+    } else if(c==='\\'&&i+1<s.length){cur+=s[++i];quoted=true;}
+    else if(c==='"'||c==="'"){quote=c;quoted=true;}
     else if(/\s/.test(c)){if(cur||quoted){out.push(cur);cur='';quoted=false;}}
     else cur+=c;
   }
@@ -1836,7 +1842,9 @@ function buildLibCmd(){
   const exp=document.getElementById('lib-export').checked;
   let parts=['beet ls'];
   if(type)parts.push(type);
-  if(fmt)parts.push('-f "'+fmt+'"');
+  // Single quotes, not double: every format preset is beets template syntax
+  // (`$artist`), which a shell would expand to nothing inside "…".
+  if(fmt)parts.push('-f '+shellQuote(fmt));
   if(q)parts.push(q);
   if(exp)parts.push('> ~/Desktop/library.txt');
   setCmd(parts.join(' '));

--- a/beetsgui.html
+++ b/beetsgui.html
@@ -93,15 +93,6 @@
   .content { flex:1; overflow-y:auto; padding:1.25rem; padding-bottom:0; }
   .tab-panel { display:none; }
   .tab-panel.active { display:block; }
-  .cmd-box { flex-shrink:0; border-top:1px solid var(--border); background:var(--bg); }
-  .cmd-box summary { cursor:pointer; color:var(--text3); font-size:10px; letter-spacing:0.06em; text-transform:uppercase; padding:0.5rem 1.25rem; user-select:none; }
-  .cmd-box summary:hover { color:var(--text2); }
-  .cmd-box[open] summary { border-bottom:1px solid var(--border); }
-  .cmd-box-body { display:flex; align-items:center; gap:0.5rem; padding:0.6rem 1.25rem; }
-  .cmd-field { flex:1; background:var(--bg2); border:1px solid var(--border2); border-radius:var(--radius); color:var(--accent); font-family:var(--font-mono); font-size:12px; padding:0.5rem 0.75rem; outline:none; overflow-x:auto; white-space:nowrap; }
-  .btn-copy { background:var(--accent); border:none; border-radius:var(--radius); color:var(--bg); cursor:pointer; font-family:inherit; font-size:11px; font-weight:700; letter-spacing:0.08em; padding:0.45rem 1rem; text-transform:uppercase; transition:opacity 0.1s; white-space:nowrap; }
-  .btn-copy:hover { opacity:0.85; }
-  .btn-copy.copied { background:var(--green); }
   label { color:var(--text2); font-weight:500; font-size:11px; letter-spacing:0.06em; text-transform:uppercase; }
   input[type="text"],input[type="password"],input[type="number"],select,textarea { background:var(--bg2); border:1px solid var(--border2); border-radius:var(--radius); color:var(--text); font-family:var(--font-mono); font-size:12px; padding:0.4rem 0.6rem; outline:none; width:100%; transition:border-color 0.1s; }
   input:focus,select:focus,textarea:focus { border-color:var(--accent2); }
@@ -470,21 +461,25 @@
         <div class="lib-results" id="lib-results"><div class="lib-empty">Loading…</div></div>
       </div>
       <div class="section">
-        <div class="section-title">Command</div>
+        <div class="section-title">Export formatted list</div>
         <div class="field">
-          <label><span>Output format</span> <span class="mono">-f</span>
-            <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Use $artist, $album, $year, $title, $format, $bitrate, $path etc. to shape output.</span></span>
+          <label><span>Format</span>
+            <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Use $artist, $album, $year, $title, $format, $bitrate, $path etc. to shape each line.</span></span>
           </label>
-          <input type="text" id="lib-format" placeholder="" oninput="buildLibCmd()">
+          <input type="text" id="lib-format" placeholder="">
         </div>
         <div class="btn-row">
           <button class="btn btn-sm" onclick="setFormat('$artist - $album ($year)')"><span>artist · album · year</span></button>
           <button class="btn btn-sm" onclick="setFormat('[$format] $bitrate $artist - $title')">format · bitrate</button>
           <button class="btn btn-sm" onclick="setFormat('$path')"><span>path</span></button>
-          <button class="btn btn-sm" onclick="setFormat('$artist - $title | BPM: $bpm | Key: $key')">BPM + Key</button>
+          <button class="btn btn-sm" onclick="setFormat('$artist - $title | BPM: $bpm | Key: $initial_key')">BPM + Key</button>
         </div>
         <div class="field">
-          <label class="check-item"><input type="checkbox" id="lib-export" onchange="buildLibCmd()"><span>Export to file</span> <span class="mono">&gt; ~/Desktop/library.txt</span></label>
+          <label>Save to</label>
+          <input type="text" id="lib-export-dest" value="~/Desktop/library.txt">
+        </div>
+        <div class="btn-row">
+          <button class="btn btn-primary btn-sm" onclick="exportFormat()"><span>Export</span></button>
         </div>
       </div>
       <hr class="divider">
@@ -941,13 +936,6 @@
     <button class="row-btn" onclick="stopPlayback()" title="Stop and clear queue">✕</button>
   </div>
 
-  <details class="cmd-box" id="cmd-box">
-    <summary>Command</summary>
-    <div class="cmd-box-body">
-      <input type="text" class="cmd-field" id="cmd-out" readonly value="beet import ~/Music">
-      <button class="btn-copy" id="copy-btn" onclick="copyCmd()">Copy</button>
-    </div>
-  </details>
 
 </div>
 <script>
@@ -959,7 +947,7 @@ function switchTab(name,btn){
   document.getElementById('tab-'+name).classList.add('active');
   if(btn)btn.classList.add('active');
   activeTab=name;
-  if(name==='library'){buildLibCmd();loadLibrary();}
+  if(name==='library'){loadLibrary();}
   if(name==='recover'){loadTraktor();}
 }
 // ⌘O's target. The filter has no single search box — it has condition rows —
@@ -1072,16 +1060,6 @@ document.addEventListener('keydown',e=>{
   // search in Obsidian.
   if((e.metaKey||e.ctrlKey)&&(e.key==='o'||e.key==='O')){e.preventDefault();focusFilter();}
 });
-function setCmd(cmd){document.getElementById('cmd-out').value=cmd;}
-function copyCmd(){
-  const v=document.getElementById('cmd-out').value;
-  navigator.clipboard.writeText(v).then(()=>{
-    const b=document.getElementById('copy-btn');
-    b.textContent='Copied!';b.classList.add('copied');
-    setTimeout(()=>{b.textContent='Copy';b.classList.remove('copied');},1800);
-  });
-}
-
 function setupDrop(zoneId,targetId,onDrop){
   const zone=document.getElementById(zoneId);if(!zone)return;
   zone.addEventListener('dragover',e=>{e.preventDefault();e.dataTransfer.dropEffect='copy';zone.classList.add('drag-over');});
@@ -1771,7 +1749,6 @@ function showFilterNote(msg){
   el.style.display=msg?'':'none';
 }
 function afterFilterChange(){
-  buildLibCmd();
   loadLibrary();
 }
 function currentQuery(){return libFilterRaw.trim();}
@@ -1832,24 +1809,22 @@ function openAction(id){
   el.scrollIntoView({behavior:'smooth',block:'start'});
 }
 
-function buildLibCmd(){
-  const q=currentQuery();
-  // Same Albums/Tracks/Artists choice that drives the results panel — beet
-  // ls has no "list artists" mode, so Artists falls back to plain track
-  // listing here, same as the default.
-  const type=libMode==='albums'?'-a':'';
-  const fmt=document.getElementById('lib-format').value.trim();
-  const exp=document.getElementById('lib-export').checked;
-  let parts=['beet ls'];
-  if(type)parts.push(type);
-  // Single quotes, not double: every format preset is beets template syntax
-  // (`$artist`), which a shell would expand to nothing inside "…".
-  if(fmt)parts.push('-f '+shellQuote(fmt));
-  if(q)parts.push(q);
-  if(exp)parts.push('> ~/Desktop/library.txt');
-  setCmd(parts.join(' '));
+function setFormat(f){document.getElementById('lib-format').value=f;}
+// Renders the current filter's matches through a beets template
+// ($artist, $bpm, ...) server-side and writes the result to a file —
+// replaces the old "beet ls -f ... > dest" copy-paste command (#12).
+function exportFormat(){
+  const format=document.getElementById('lib-format').value.trim();
+  const dest=document.getElementById('lib-export-dest').value.trim();
+  if(!format){renderResult('<div class="lib-empty">Enter a format first.</div>');return;}
+  if(!dest){renderResult('<div class="lib-empty">Enter a destination file.</div>');return;}
+  renderResult('<div class="lib-empty">Exporting…</div>');
+  postJSON('/library/export',{format,dest,...scopeBody()})
+    .then(data=>renderResult(data.ok
+      ?'<div class="alert alert-green">Wrote '+data.count+' line'+(data.count===1?'':'s')+' to '+escapeHtml(data.path)+'</div>'
+      :'<div class="lib-empty">'+escapeHtml(data.error||'Failed.')+'</div>'))
+    .catch(()=>renderResult('<div class="lib-empty">Could not reach the server.</div>'));
 }
-function setFormat(f){document.getElementById('lib-format').value=f;buildLibCmd();}
 
 function escapeHtml(s){
   return String(s).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
@@ -1876,7 +1851,6 @@ function setLibMode(){
   libMode=document.querySelector('input[name="lib-mode"]:checked').value;
   fillLibSorts();
   loadLibrary();
-  buildLibCmd();
 }
 // The Tracks sort dropdown also offers every other real metadata column
 // (bpm, initial_key, genres, label, ...) — fetched once from /info/fields
@@ -2834,11 +2808,6 @@ function toggleBp4Method(){
   document.getElementById('bp4-token-wrap').style.display=isUp?'none':'block';
   buildConfig();
 }
-(function(){
-  const box=document.getElementById('cmd-box');
-  if(localStorage.getItem('cmdBoxOpen')==='1')box.open=true;
-  box.addEventListener('toggle',()=>localStorage.setItem('cmdBoxOpen',box.open?'1':'0'));
-})();
 // Gnomon's TOTD/DIST are real OpenType variable axes the font itself draws
 // a sundial shadow with — not a CSS trick. .face stays at DIST=0 (the plain
 // letterform) at the same TOTD as .shadow, so both layers share identical

--- a/importsession.py
+++ b/importsession.py
@@ -510,6 +510,11 @@ def start(path=None, mode='interactive', paths=None, handling='copy',
         raise ValueError(f'handling must be one of {list(HANDLING)}')
     if paths is None:
         paths = [path]
+    # A missing path is missing, not the empty string: `[None]` is a
+    # non-empty list, and _resolve_path('') is os.path.abspath('') — the
+    # server's own working directory, which exists, so the import would
+    # quietly run against it instead of failing here (#12).
+    paths = [p for p in paths if p and str(p).strip()]
     if not paths:
         raise ValueError('no path specified')
     resolved = [_resolve_path(p) for p in paths]

--- a/libops.py
+++ b/libops.py
@@ -188,14 +188,18 @@ def apply_modify(field, value, query):
 # Both beets internals already take a `pretend` flag — reused directly.
 
 def update(query, pretend):
-    """Returns the printed diff lines (deleted files, changed fields)."""
+    """Resync the library from what's actually on disk: catches files
+    edited or moved outside this app (Traktor, Swinsian, Finder). Returns
+    the printed diff lines (deleted files, changed fields)."""
     lib = get_library()
     return _capture(_update_items, lib, split_query(query), False, False,
                      pretend, None)
 
 
 def write(query, pretend):
-    """Returns the printed diff lines (tags that would be/were written)."""
+    """Push the database's metadata out to the files' tags — the reverse of
+    update(). Returns the printed diff lines (tags that would be/were
+    written)."""
     lib = get_library()
     return _capture(_write_items, lib, split_query(query), pretend, False)
 
@@ -264,15 +268,25 @@ def matching_ids(query):
     Measured at 5,000 albums / 40,000 items (#12): ~630ms for a free-text
     search, ~280ms for a field match, against ~5ms for the unfiltered list.
     Still under the 1s the issue asks for, so it stays. The upgrade, when it
-    stops being fine, is to splice beets' own `Query.clause()` into the
-    list SQL — which
-    needs the custom SQL functions (regexp, bytelower) that the read-only
-    connection in server.py deliberately doesn't register.
+    stops being fine, is to splice beets' own `Query.clause()` into the list
+    SQL — which needs the custom SQL functions (regexp, bytelower) that the
+    read-only connection in server.py deliberately doesn't register.
     """
     lib = get_library()
     items = list(lib.items(split_query(query)))
     return ([i.id for i in items],
             sorted({i.album_id for i in items if i.album_id}))
+
+
+def render_format(fmt, query):
+    """One rendered line per matching item, beets template syntax (`$artist`,
+    `$bpm`, `$path`, ...) — the same engine `preview_modify`'s replacement
+    value goes through. This is what the Library tab's format presets (was:
+    a `beet ls -f` string to copy-paste) now render server-side instead."""
+    lib = get_library()
+    template = functemplate.template(fmt)
+    return [item.evaluate_template(template)
+            for item in lib.items(split_query(query))]
 
 
 def fields():

--- a/libops.py
+++ b/libops.py
@@ -58,14 +58,23 @@ PROTECTED_FIELDS = {'path', 'id', 'album_id'}
 
 
 def split_query(query):
-    """Split a beets query string. Raises UserError on unbalanced quotes,
-    which the endpoints turn into a 400 rather than a 500."""
+    """Split a beets query string the way the shell would.
+
+    An unbalanced quote falls back to a plain whitespace split rather than
+    erroring. `Don't Stop`, `O'Brien`, `Guns N' Roses` are ordinary things to
+    type into a search box, and shlex reads that apostrophe as an unclosed
+    quote — a 400 there is the wrong answer for a music library, where the
+    apostrophe is a letter far more often than it is punctuation. Everything
+    the UI quotes itself is balanced (shellQuote in beetsgui.html), so this
+    fallback only ever sees hand-typed input, where matching the literal
+    words beats refusing to search.
+    """
     if not query:
         return []
     try:
         return shlex.split(query)
-    except ValueError as e:
-        raise UserError(f'could not parse query: {e}')
+    except ValueError:
+        return query.split()
 
 
 # An `ids` scope becomes one `id:` term per id, so the whole set has to fit
@@ -197,25 +206,32 @@ def write(query, pretend):
 # printed text, since these are display-only, nothing to preview or apply.
 
 def stats():
+    """The same totals as beets' `stats`, but as one SQL aggregate.
+
+    beets walks every Item to sum these, which is a full ORM materialisation
+    of the library; measured at ~2.9s over 40k tracks (#12). That cost sits
+    on the page-load path, not just this panel — the first-run banner asks
+    /info/stats whether the library is empty. The CAST reproduces beets' own
+    per-item `int()` truncation exactly, so the byte total is unchanged.
+    """
     lib = get_library()
-    items = lib.items()
-    total_size = total_time = total_items = 0
-    artists, albums, album_artists = set(), set(), set()
-    for item in items:
-        total_size += int(item.length * item.bitrate / 8)
-        total_time += item.length
-        total_items += 1
-        artists.add(item.artist)
-        album_artists.add(item.albumartist)
-        if item.album_id:
-            albums.add(item.album_id)
+    with lib.transaction() as tx:
+        tracks, total_time, total_size, artists, album_artists, albums = tx.query('''
+            SELECT COUNT(*),
+                   COALESCE(SUM(length), 0),
+                   COALESCE(SUM(CAST(length * bitrate / 8 AS INTEGER)), 0),
+                   COUNT(DISTINCT artist),
+                   COUNT(DISTINCT albumartist),
+                   COUNT(DISTINCT album_id)
+            FROM items
+        ''')[0]
     return {
-        'tracks': total_items,
+        'tracks': tracks,
         'total_time': human_seconds(total_time),
         'total_size': human_bytes(total_size),
-        'artists': len(artists),
-        'albums': len(albums),
-        'album_artists': len(album_artists),
+        'artists': artists,
+        'albums': albums,
+        'album_artists': album_artists,
     }
 
 
@@ -245,8 +261,11 @@ def matching_ids(query):
     than either.
 
     ponytail: materialises the whole match set to render one page of 200.
-    Fine at personal-library scale. The upgrade, if it ever stops being
-    fine, is to splice beets' own `Query.clause()` into the list SQL — which
+    Measured at 5,000 albums / 40,000 items (#12): ~630ms for a free-text
+    search, ~280ms for a field match, against ~5ms for the unfiltered list.
+    Still under the 1s the issue asks for, so it stays. The upgrade, when it
+    stops being fine, is to splice beets' own `Query.clause()` into the
+    list SQL — which
     needs the custom SQL functions (regexp, bytelower) that the read-only
     connection in server.py deliberately doesn't register.
     """

--- a/server.py
+++ b/server.py
@@ -1000,6 +1000,35 @@ def export_m3u():
     return jsonify({'ok': True, 'count': len(items), 'path': str(path)})
 
 
+@app.route('/library/export', methods=['POST'])
+def library_export():
+    """Write one rendered beets-template line per matching item to `dest`.
+    Body: {"scope": {...}, "format": "$artist - $title", "dest": "..."}.
+
+    Replaces the Library tab's old "beet ls -f ... > dest" copy-paste
+    string (#12): same beets template engine, same 4 format presets, but
+    rendered and written here instead of by a shell the user had to paste
+    into. `scope` is the shared filter, same as every other Library action.
+    """
+    if busy := _busy_response():
+        return busy
+    data = request.get_json(silent=True) or {}
+    fmt = (data.get('format') or '').strip()
+    dest = (data.get('dest') or '').strip()
+    if not fmt:
+        return jsonify({'ok': False, 'error': 'format is required'}), 400
+    if not dest:
+        return jsonify({'ok': False, 'error': 'dest is required'}), 400
+    try:
+        lines = libops.render_format(fmt, libops.scope_query(data))
+    except UserError as e:
+        return jsonify({'ok': False, 'error': str(e)}), 400
+    path, error = _write_list(dest, lines)
+    if error:
+        return jsonify({'ok': False, 'error': error}), 400
+    return jsonify({'ok': True, 'count': len(lines), 'path': str(path)})
+
+
 @app.route('/export/playlists', methods=['POST'])
 def export_playlists():
     """Write one .m3u per immediate subfolder of `src` into

--- a/server.py
+++ b/server.py
@@ -70,6 +70,9 @@ SAFARI_APP_NAME = 'BeetsGUI'
 app = Flask(__name__)
 
 
+LOCAL_ORIGINS = (f'http://localhost:{PORT}', f'http://127.0.0.1:{PORT}')
+
+
 @app.before_request
 def _reject_foreign_host():
     """Block DNS-rebinding: only serve requests addressed to this loopback
@@ -78,6 +81,29 @@ def _reject_foreign_host():
     every endpoint here, CORS preflight or not."""
     if request.host not in (f'localhost:{PORT}', f'127.0.0.1:{PORT}'):
         return jsonify({'ok': False, 'error': 'bad host'}), 403
+
+
+@app.before_request
+def _reject_foreign_origin():
+    """Block cross-site requests from a page the user merely visited.
+
+    The Host check above does not see these: a POST from evil.example to
+    localhost still carries `Host: localhost:<port>`. Missing CORS headers
+    only stop the attacker *reading* the reply — with a CORS-safelisted
+    content type (text/plain) the browser sends the request without a
+    preflight and the side effect happens anyway. Every mutating endpoint
+    reads its body with get_json(silent=True), so such a request arrives as
+    an empty dict and each one has to defend itself; /import/start did not,
+    and started an import of the server's working directory (#12).
+
+    Only requests that *declare* a foreign origin are refused. A browser
+    always sends Origin cross-origin, so the attack shape is covered; curl
+    and the test suite send none, and CSRF is not a threat model they are
+    part of.
+    """
+    origin = request.headers.get('Origin')
+    if origin and origin not in LOCAL_ORIGINS:
+        return jsonify({'ok': False, 'error': 'cross-origin request refused'}), 403
 
 
 @app.errorhandler(UserError)

--- a/test_filter.py
+++ b/test_filter.py
@@ -11,8 +11,9 @@ that actually bites:
    rewrites the user's filter.
 
 2. That the JS agrees with **beets** about what it just wrote. The compiler
-   quotes values with `"` and joins OR terms with a comma token; the parser
-   is a hand-written shlex-alike. Any drift between that and Python's shlex
+   POSIX single-quotes values (the same string is pasted into a shell, see
+   shellQuote) and joins OR terms with a comma token; the parser is a
+   hand-written shlex-alike. Any drift between that and Python's shlex
    makes the rows say one thing and the library do another — and it would
    drift silently, because the JS half never sees the server's opinion.
    So every compiled query is re-parsed here by beets itself and matched
@@ -65,6 +66,29 @@ BEYOND_ROWS = [
 ]
 
 
+# Values a real music library can contain that a shell would otherwise act
+# on rather than pass through. `$(echo PWNED)` stands in for command
+# substitution: harmless when the quoting holds, unmistakable when it does
+# not. `$artist - $album ($year)` is not hostile at all — it is what every
+# format preset puts in `beet ls -f`, and double quotes would let the shell
+# expand it to nothing before beets ever saw it (#12).
+SHELL_HOSTILE = [
+    'plain',
+    '$(echo PWNED)',
+    '`echo PWNED`',
+    'a;echo PWNED',
+    'a && echo PWNED',
+    '$HOME',
+    '*',
+    '~',
+    "it's here",
+    'a "quoted" bit',
+    'Blæst æøå',
+    '日本語 🎵',
+    '$artist - $album ($year)',
+]
+
+
 def js_block():
     """The filter compiler/parser, lifted out of the page."""
     src = HTML.read_text()
@@ -78,7 +102,8 @@ def run_js():
     script = js_block() + '''
 const CASES=''' + json.dumps(CASES) + ''';
 const BEYOND=''' + json.dumps(BEYOND_ROWS) + ''';
-const out={compiled:[],roundtrip:[],beyond:[]};
+const HOSTILE=''' + json.dumps(SHELL_HOSTILE) + ''';
+const out={compiled:[],roundtrip:[],beyond:[],quoted:HOSTILE.map(shellQuote)};
 for(const c of CASES){
   libFilter={match:c.match,rows:c.rows.map(r=>({...r}))};
   const q=compileFilter();
@@ -144,8 +169,8 @@ def test_beets_agrees(result):
         expected = {
             'artist:Burial': {'Burial'},
             'artist:=Burial': {'Burial'},
-            'albumartist:="Aphex Twin"': {'Aphex Twin'},
-            'album:"a \\"quoted\\" bit"': {'Someone Else'},
+            "albumartist:='Aphex Twin'": {'Aphex Twin'},
+            "album:'a \"quoted\" bit'": {'Someone Else'},
             'year:2000..': {'Burial', 'Someone Else', 'Nobody'},
             'year:..2010': {'Aphex Twin', 'Burial', 'Nobody'},
             'year:2000.. year:..2010': {'Burial', 'Nobody'},
@@ -166,11 +191,37 @@ def test_beets_agrees(result):
         assert got == {'Nobody'}, f'{apos!r} selected {got}'
 
 
+def test_shell_agrees(result):
+    """A real shell must hand beets exactly the token the row meant.
+
+    The compiled query is displayed as a `beet ls …` command with a Copy
+    button next to it, so a shell — not shlex — is what re-splits it when the
+    user pastes. Anything the shell expands on the way is both a correctness
+    bug (`$artist` reaching beets as an empty string) and, for a value that
+    came out of a file's tags, an injection (#12). Checking the argv a real
+    bash produces is the only way to see that; shlex agrees with the row
+    either way, which is exactly why this drifted unnoticed.
+    """
+    for value, quoted in zip(SHELL_HOSTILE, result['quoted']):
+        term = f'artist:{quoted}'
+        r = subprocess.run(['bash', '-c', f'printf "%s\\n" {term}'],
+                           capture_output=True, text=True, cwd='/')
+        assert r.returncode == 0, f'{term!r} is not even valid shell: {r.stderr}'
+        argv = r.stdout.rstrip('\n').split('\n')
+        assert argv == [f'artist:{value}'], (
+            f'pasting {term!r} gives beets {argv!r}, not '
+            f'{[f"artist:{value}"]!r} — the shell got at it')
+        # …and the server has to read that same string back the same way.
+        assert shlex.split(term) == [f'artist:{value}'], (
+            f'{term!r}: shlex and bash disagree')
+
+
 def main():
     result = run_js()
     test_roundtrip(result)
     test_beyond_rows_stays_raw(result)
     test_beets_agrees(result)
+    test_shell_agrees(result)
     print('ok')
 
 

--- a/test_importsession.py
+++ b/test_importsession.py
@@ -948,6 +948,69 @@ def test_kill_minus_9_mid_decision_recovery():
     print('kill -9 mid-decision recovery: ok')
 
 
+def test_cross_site_post_is_refused():
+    """A page the user merely visited must not be able to act (#12).
+
+    The #28 host check does not see this one: a POST from evil.example to
+    localhost still carries `Host: localhost:<port>`. The other half of the
+    argument — "JSON content type forces a preflight the server never
+    answers" — has a hole, because `text/plain` is CORS-safelisted and gets
+    no preflight, and every endpoint reads its body with
+    get_json(silent=True), so it arrives as an empty dict rather than being
+    rejected. 19 of the 22 mutating endpoints happened to reject that empty
+    dict on their own; /import/start did not, and started an import of the
+    server's own working directory.
+
+    Both halves are asserted: the origin guard in front, and the missing
+    path behind it, so neither one silently becomes the only thing holding.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix='beetsgui-csrf-'))
+    beetsdir = tmp / 'beets'
+    beetsdir.mkdir()
+    (beetsdir / 'config.yaml').write_text(
+        f'directory: {tmp / "library"}\n'
+        f'library: {beetsdir / "library.db"}\n'
+        'import:\n    write: no\n')
+
+    proc = start_server(beetsdir)
+    try:
+        def post_raw(path, headers):
+            req = urllib.request.Request(BASE + path, data=b'', method='POST',
+                                         headers=headers)
+            try:
+                with urllib.request.urlopen(req, timeout=30) as r:
+                    return r.status, json.load(r)
+            except urllib.error.HTTPError as e:
+                return e.code, json.load(e)
+
+        # The exact request a malicious page can make with no preflight.
+        for route in ('/import/start', '/library/remove', '/convert/start',
+                      '/duplicates/delete'):
+            status, body = post_raw(route, {'Content-Type': 'text/plain',
+                                            'Origin': 'https://evil.example'})
+            assert status == 403, (route, status, body)
+            assert 'cross-origin' in body.get('error', ''), (route, body)
+
+        # The app's own origin still gets through (this is what would break
+        # if the guard were written too tightly to be usable).
+        status, body = post_raw('/library/count',
+                                {'Content-Type': 'application/json',
+                                 'Origin': f'http://127.0.0.1:{PORT}'})
+        assert status == 200 and body['ok'], body
+
+        # And with the guard passed, a body with no path is still refused —
+        # os.path.abspath('') is the server's working directory, so this
+        # used to start a real import of wherever server.py was launched.
+        status, body = post_raw('/import/start',
+                                {'Content-Type': 'application/json'})
+        assert status == 400, (status, body)
+        assert 'no path specified' in body.get('error', ''), body
+    finally:
+        stop_server(proc)
+        shutil.rmtree(tmp, ignore_errors=True)
+    print('cross-site POST refused, empty import path refused: ok')
+
+
 if __name__ == '__main__':
     main()
     test_quality_rank_real_encoders()
@@ -956,4 +1019,5 @@ if __name__ == '__main__':
     test_missing_ffmpeg_dependency()
     test_scale_library_endpoints()
     test_kill_minus_9_mid_decision_recovery()
+    test_cross_site_post_is_refused()
     print('all #12 stress/correctness checks passed')

--- a/test_importsession.py
+++ b/test_importsession.py
@@ -18,6 +18,7 @@ import sys
 import tempfile
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -442,5 +443,517 @@ def main():
         shutil.rmtree(tmp, ignore_errors=True)
 
 
+def make_track_encoded(path, artist, album, title, track, extra_args):
+    """Like make_track, but with extra ffmpeg args (bitrate/sample format/
+    codec) so the fixture is real encoder output, not the anullsrc default —
+    for the quality_rank() check below, which needs genuine bitdepth/bitrate
+    numbers per format, not zeros."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run([
+        'ffmpeg', '-loglevel', 'error', '-y',
+        '-f', 'lavfi', '-i', 'sine=frequency=440:duration=1',
+        '-metadata', f'artist={artist}', '-metadata', f'album={album}',
+        '-metadata', f'title={title}', '-metadata', f'track={track}',
+        *extra_args, str(path),
+    ], check=True)
+
+
+def test_quality_rank_real_encoders():
+    """#12 scope 2: quality_rank() and the 24-bit cap against real
+    ffmpeg-encoded fixtures, not synthetic bitdepth/bitrate numbers.
+
+    Real MP3 128/192/320kbps, FLAC and WAV at 16- and 24-bit, ALAC, and a
+    32-bit-float WAV to exercise _MAX_RANKED_BITDEPTH. No server needed —
+    this drives importsession.quality_rank() directly against MediaFile
+    readings of real files.
+    """
+    from mediafile import MediaFile
+    from importsession import quality_rank, LOSSLESS_FORMATS
+
+    tmp = Path(tempfile.mkdtemp(prefix='beetsgui-quality-'))
+
+    class Track:
+        def __init__(self, mf):
+            self.format = mf.format          # real property: TYPES[mf.type],
+                                              # e.g. 'WAVE' not 'WAV'.
+            self.bitrate = mf.bitrate
+            self.bitdepth = getattr(mf, 'bitdepth', None)
+            self.samplerate = mf.samplerate
+
+    def make(name, extra_args):
+        p = tmp / name
+        make_track_encoded(p, 'Q', 'Q', 'Q', 1, extra_args)
+        return Track(MediaFile(p))
+
+    mp3_128 = make('mp3_128.mp3', ['-b:a', '128k'])
+    mp3_192 = make('mp3_192.mp3', ['-b:a', '192k'])
+    mp3_320 = make('mp3_320.mp3', ['-b:a', '320k'])
+    flac_16 = make('flac_16.flac', ['-sample_fmt', 's16'])
+    flac_24 = make('flac_24.flac', ['-sample_fmt', 's32', '-bits_per_raw_sample', '24'])
+    wav_16  = make('wav_16.wav', ['-c:a', 'pcm_s16le'])
+    wav_24  = make('wav_24.wav', ['-c:a', 'pcm_s24le'])
+    wav_32f = make('wav_32f.wav', ['-c:a', 'pcm_f32le'])
+    alac    = make('alac.m4a', ['-c:a', 'alac'])
+
+    assert mp3_128.format == 'MP3' and mp3_128.bitdepth in (0, None), mp3_128.__dict__
+    assert wav_16.format == 'WAVE', (
+        'real MediaFile.format for a .wav is "WAVE" (TYPES[type]), not "WAV" — '
+        'importsession.LOSSLESS_FORMATS must key off that exact string or a '
+        'lossless WAV silently ranks as lossy')
+    assert flac_16.format == 'FLAC' and alac.format == 'ALAC'
+
+    # Lossy always ranks below lossless, regardless of bitrate/bitdepth.
+    assert quality_rank([mp3_320]) < quality_rank([flac_16]), \
+        'a 320kbps MP3 must never outrank a lossless FLAC'
+    assert quality_rank([mp3_320]) < quality_rank([wav_16]), (
+        'a 320kbps MP3 must never outrank a lossless WAV — this is the case '
+        'the WAVE/WAV format-string mismatch would silently break')
+
+    # Bitrate orders lossy tracks against each other.
+    assert quality_rank([mp3_128]) < quality_rank([mp3_192]) < quality_rank([mp3_320])
+
+    # Bitdepth orders lossless tracks of the same format.
+    assert quality_rank([flac_16]) < quality_rank([flac_24])
+    assert quality_rank([wav_16]) < quality_rank([wav_24])
+
+    # _MAX_RANKED_BITDEPTH: a real 32-bit-float WAV (bitdepth=32 as MediaFile
+    # reports it) must rank exactly like a real 24-bit file, not above it —
+    # the app's own convert step never produces better than 24-bit ALAC.
+    assert wav_32f.bitdepth == 32, wav_32f.__dict__       # confirm the fixture is genuine
+    assert quality_rank([wav_32f]) == quality_rank([wav_24]), \
+        (quality_rank([wav_32f]), quality_rank([wav_24]))
+    assert quality_rank([wav_32f]) == quality_rank([flac_24])
+
+    shutil.rmtree(tmp, ignore_errors=True)
+    print('quality_rank real-encoder check: ok')
+
+
+def test_unicode_and_edge_case_metadata():
+    """#12 scope 3: Danish æøå, emoji, CJK, embedded quotes and a very long
+    string through the real pipeline — tags -> /unimported -> import
+    decision (asis, so the tag is what lands) -> /library free-text search.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix='beetsgui-unicode-'))
+    beetsdir = tmp / 'beets'
+    beetsdir.mkdir()
+    plugindir = beetsdir / 'plugins'
+    plugindir.mkdir()
+    (plugindir / 'stubsource.py').write_text(STUB_PLUGIN)
+    (beetsdir / 'config.yaml').write_text(
+        f'directory: {tmp / "library"}\n'
+        f'library: {beetsdir / "library.db"}\n'
+        f'pluginpath: [{plugindir}]\n'
+        'plugins: [stubsource]\n'
+        'import:\n'
+        '    resume: ask\n'
+        '    copy: yes\n'
+        '    write: no\n'
+    )
+    src = tmp / 'incoming'
+
+    # (label, artist, album, title, search needle). The needle is a
+    # quote-free substring for the /library free-text-search assertion;
+    # searching *with* an apostrophe is checked separately below.
+    cases = [
+        ('Danish', 'Søren Ærøskøbing', 'Blåbær Café', 'Rødgrød med fløde', 'Søre'),
+        ('Emoji', 'DJ 🔥🎧', '🎶 Party Mix 🎶', 'Track 😀 One', '🔥🎧'),
+        ('CJK', '田中太郎', 'ラウンジ', '夜の東京', '田中太郎'),
+        ('Quotes', 'O\'Brien "The Mixer"', 'Rock\'n\'Roll "Live"', 'She said "hi"', 'Brien'),
+        ('LongString', 'A' * 5, 'B' * 400, 'C' * 400, 'A' * 5),
+    ]
+
+    proc = start_server(beetsdir)
+    try:
+        for label, artist, album, title, needle in cases:
+            folder = src / label
+            make_track(folder / '01.mp3', artist, album, title, 1)
+
+            # /unimported must detect the real file with unicode tags intact.
+            with urllib.request.urlopen(
+                    f'{BASE}/unimported?dir={urllib.parse.quote(str(folder))}',
+                    timeout=30) as r:
+                un = json.load(r)
+            assert un['ok'] and un['total_files'] == 1, (label, un)
+
+            # Import asis so the metadata that lands is exactly the tag.
+            for event in run(folder):
+                if event['type'] == 'decision':
+                    assert event['current']['artist'] == artist, (label, event)
+                    decide(event, choice='asis')
+
+            rows = albums_in(beetsdir)
+            assert (artist, album) in rows, (label, artist, album, rows)
+
+            # /library free-text search must find it by a substring of the
+            # unicode/emoji/CJK/quoted artist name.
+            with urllib.request.urlopen(
+                    f'{BASE}/library?q={urllib.parse.quote(needle)}',
+                    timeout=30) as r:
+                found = json.load(r)
+            assert found['ok'], (label, found)
+            assert any(a['albumartist'] == artist for a in found['albums']), \
+                (label, needle, found['albums'])
+
+        # An apostrophe is a letter in a music library, not an unclosed
+        # quote. /library's free-text search runs through beets' shlex-style
+        # tokenizer (libops.split_query), which used to raise on names as
+        # ordinary as O'Brien or Guns N' Roses and surface as a 400 (#12).
+        # It has to search now, and it has to find the real track.
+        for needle in ("O'Brien", "Don't Stop", "N' Roses"):
+            with urllib.request.urlopen(
+                    f'{BASE}/library?q={urllib.parse.quote(needle)}',
+                    timeout=10) as r:
+                found = json.load(r)
+            assert found['ok'], (needle, found)
+        # The one that must actually match: an artist carrying an apostrophe.
+        with urllib.request.urlopen(
+                f'{BASE}/library?q={urllib.parse.quote("O\'Brien")}',
+                timeout=10) as r:
+            found = json.load(r)
+        assert any("O'Brien" in (a['albumartist'] or '') for a in found['albums']), \
+            f"searching for O'Brien found {found['albums']}"
+    finally:
+        stop_server(proc)
+        shutil.rmtree(tmp, ignore_errors=True)
+    print('unicode/edge-case metadata pipeline: ok')
+
+
+def test_shell_metacharacter_and_space_paths():
+    """#12 scope 3: paths with spaces, a unicode directory name, and
+    shell-metacharacter directory names ($, backticks, ;) all the way
+    through /import/start. The importer runs in-process (no shell spawned
+    for the actual import — see importsession.WebImportSession.run()), so
+    these should just be inert bytes in a path; this proves it rather than
+    assuming it from reading the code.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix='beetsgui-shellchars-'))
+    beetsdir = tmp / 'beets'
+    beetsdir.mkdir()
+    plugindir = beetsdir / 'plugins'
+    plugindir.mkdir()
+    (plugindir / 'stubsource.py').write_text(STUB_PLUGIN)
+    (beetsdir / 'config.yaml').write_text(
+        f'directory: {tmp / "library"}\n'
+        f'library: {beetsdir / "library.db"}\n'
+        f'pluginpath: [{plugindir}]\n'
+        'plugins: [stubsource]\n'
+        'import:\n'
+        '    resume: ask\n'
+        '    copy: yes\n'
+        '    write: no\n'
+    )
+    src = tmp / 'incoming'
+    dirnames = [
+        'has spaces',
+        'has$dollar',
+        'has`backtick`',
+        'has;semicolon',
+        'has&ampersand',
+        'unicode-æøå-日本語',
+    ]
+
+    proc = start_server(beetsdir)
+    try:
+        for name in dirnames:
+            folder = src / name
+            make_album(folder, f'Artist {name}', f'Album {name}', ['Only'])
+            for event in run(folder):
+                if event['type'] == 'decision':
+                    decide(event, choice='asis')
+            assert (f'Artist {name}', f'Album {name}') in albums_in(beetsdir), name
+    finally:
+        stop_server(proc)
+        shutil.rmtree(tmp, ignore_errors=True)
+    print('shell-metacharacter / unicode / space path import: ok')
+
+
+def test_missing_ffmpeg_dependency():
+    """#12 scope 4: hide ffmpeg from PATH and exercise the one feature that
+    actually shells out to it (POST /convert/start, via beets' convert
+    plugin) — clear error vs silent failure/hang.
+
+    fd and xld: grepping the whole repo turns up no subprocess/shell call
+    to either — fd is mentioned only as descriptive UI copy (the /scan/*
+    endpoints reimplement the same walk in Python, per their own
+    docstrings), and xld doesn't appear anywhere in the app or README.
+    Hiding them from PATH would exercise nothing this app calls, so there
+    is nothing to test for those two beyond noting they're not
+    dependencies of the current code.
+    """
+    if not shutil.which('ffmpeg'):
+        print('ffmpeg not on host PATH - skipping (nothing to hide)')
+        return
+
+    tmp = Path(tempfile.mkdtemp(prefix='beetsgui-noffmpeg-'))
+    beetsdir = tmp / 'beets'
+    beetsdir.mkdir()
+    plugindir = beetsdir / 'plugins'
+    plugindir.mkdir()
+    (plugindir / 'stubsource.py').write_text(STUB_PLUGIN)
+    convert_dest = tmp / 'converted'
+    (beetsdir / 'config.yaml').write_text(
+        f'directory: {tmp / "library"}\n'
+        f'library: {beetsdir / "library.db"}\n'
+        f'pluginpath: [{plugindir}]\n'
+        'plugins: [stubsource, convert]\n'
+        f'convert:\n'
+        f'    dest: {convert_dest}\n'
+        '    format: alac\n'
+        'import:\n'
+        '    resume: ask\n'
+        '    copy: yes\n'
+        '    write: no\n'
+    )
+    src = tmp / 'incoming'
+    make_album(src / 'one', 'Dep Artist', 'Dep Album', ['Only'], ext='flac')
+
+    # Import normally first (ffmpeg on PATH — import itself never needs it).
+    proc = start_server(beetsdir)
+    try:
+        for event in run(src / 'one'):
+            if event['type'] == 'decision':
+                decide(event, choice='asis')
+        assert ('Dep Artist', 'Dep Album') in albums_in(beetsdir)
+    finally:
+        stop_server(proc)
+
+    # Restart with ffmpeg hidden from the server process's PATH, then try
+    # to convert the track that's now in the library.
+    scrubbed = os.pathsep.join(
+        p for p in os.environ.get('PATH', '').split(os.pathsep)
+        if not (Path(p) / 'ffmpeg').exists())
+    proc = start_server(beetsdir, PATH=scrubbed)
+    try:
+        status, body = post('/convert/start',
+                            {'scope': {'query': ''}, 'format': 'alac', 'pretend': False})
+        assert status == 200 and body['ok'], body
+        job_id = body['id']
+        saw_error = False
+        saw_done = False
+        stream = urllib.request.urlopen(f'{BASE}/jobs/{job_id}/events', timeout=60)
+        for raw in stream:
+            line = raw.decode().rstrip('\n')
+            if not line.startswith('data: '):
+                continue
+            event = json.loads(line[6:])
+            if event['type'] == 'error':
+                saw_error = True
+                assert 'ffmpeg' in event['message'].lower(), event
+            if event['type'] == 'done':
+                saw_done = True
+                stream.close()
+                break
+        assert saw_done, 'convert job must finish (not hang) when ffmpeg is missing'
+        assert saw_error, 'convert job must surface a clear error when ffmpeg is missing'
+    finally:
+        stop_server(proc)
+        shutil.rmtree(tmp, ignore_errors=True)
+    print('missing-ffmpeg dependency check: clear error, no hang - ok')
+
+
+def test_scale_library_endpoints():
+    """#12 scope 1: /library, /library/tracks, /library/artists,
+    /stream, /art against a library well beyond the 2-album scratch size
+    used everywhere else in this file — enough to exercise the unindexed
+    LIKE-based free-text search's real cost, not just prove the endpoints
+    don't crash.
+
+    Kept to a few hundred albums/files here so the suite stays fast to run
+    repeatedly; the actual #12 acceptance numbers (5,000 albums / 40,000
+    items, 2,200 real audio files) were measured once by hand against this
+    same code path and are reported in the #12 findings, not re-measured on
+    every test run.
+    """
+    N_ALBUMS = 300
+    TRACKS_PER_ALBUM = 6
+    tmp = Path(tempfile.mkdtemp(prefix='beetsgui-scale-'))
+    beetsdir = tmp / 'beets'
+    beetsdir.mkdir()
+    libdir = tmp / 'library'
+    libdir.mkdir()
+    dbpath = beetsdir / 'library.db'
+    (beetsdir / 'config.yaml').write_text(
+        f'directory: {libdir}\n'
+        f'library: {dbpath}\n'
+        'import:\n'
+        '    write: no\n'
+    )
+
+    from beets.library import Library
+    lib = Library(str(dbpath))
+    con = lib._connection()
+    acols = [r[1] for r in con.execute('PRAGMA table_info(albums)')]
+    icols = [r[1] for r in con.execute('PRAGMA table_info(items)')]
+    now = time.time()
+    album_dicts, item_dicts = [], []
+    for i in range(N_ALBUMS):
+        artist = f'Scale Artist {i % 50}'
+        album = f'Scale Album {i:04d}'
+        a = {c: '' for c in acols}
+        a.update(id=i + 1, added=now, album=album, albumartist=artist,
+                albumartist_sort=artist, year=2000 + (i % 20), comp=0,
+                disctotal=1, month=0, day=0, original_year=0,
+                original_month=0, original_day=0)
+        album_dicts.append(a)
+        for t in range(1, TRACKS_PER_ALBUM + 1):
+            it = {c: '' for c in icols}
+            title = f'Scale Track {t:02d} of {album}'
+            it.update(id=i * TRACKS_PER_ALBUM + t, album_id=i + 1,
+                     path=f'{artist}/{album}/{t:02d} {title}.mp3'.encode(),
+                     title=title, artist=artist, album=album,
+                     albumartist=artist, year=2000 + (i % 20), format='MP3',
+                     bitrate=192000, bitdepth=0, samplerate=44100, channels=2,
+                     length=200.0, track=t, tracktotal=TRACKS_PER_ALBUM,
+                     disc=1, disctotal=1, added=now, mtime=now, comp=0, bpm=0,
+                     rg_track_gain=0, rg_track_peak=0, rg_album_gain=0,
+                     rg_album_peak=0, r128_track_gain=0, r128_album_gain=0)
+            item_dicts.append(it)
+    con.executemany(
+        f"INSERT INTO albums ({','.join(acols)}) VALUES ({','.join('?' * len(acols))})",
+        [[d[c] for c in acols] for d in album_dicts])
+    con.executemany(
+        f"INSERT INTO items ({','.join(icols)}) VALUES ({','.join('?' * len(icols))})",
+        [[d[c] for c in icols] for d in item_dicts])
+    con.commit()
+    lib._connection().close() if hasattr(lib, '_connection') else None
+
+    proc = start_server(beetsdir)
+    try:
+        checks = [
+            ('/library?limit=200', 'albums'),
+            ('/library?q=Scale&limit=200', 'albums'),
+            ('/library/tracks?limit=200', 'tracks'),
+            ('/library/tracks?q=Scale+Track+05&limit=200', 'tracks'),
+            ('/library/artists?limit=200', 'artists'),
+        ]
+        for path, key in checks:
+            t0 = time.monotonic()
+            with urllib.request.urlopen(f'{BASE}{path}', timeout=30) as r:
+                body = json.load(r)
+            dt = time.monotonic() - t0
+            assert body['ok'], (path, body)
+            # Generous ceiling: this is a correctness/hang guard, not a perf
+            # assertion — see the #12 findings for actual measured numbers
+            # at the real 5,000-album acceptance scale.
+            assert dt < 10, f'{path} took {dt:.2f}s against {N_ALBUMS} albums'
+
+        # /stream and /art: single-row PK lookups, id-only addressing. No
+        # real file on disk here, so 404 is the correct answer — this is
+        # checking the DB-lookup path responds promptly, not serving audio.
+        t0 = time.monotonic()
+        with urllib.request.urlopen(f'{BASE}/stream/1', timeout=10) as r:
+            pass
+    except urllib.error.HTTPError as e:
+        assert e.code == 404, e.code
+    finally:
+        stop_server(proc)
+        shutil.rmtree(tmp, ignore_errors=True)
+    print(f'scale endpoint check ({N_ALBUMS} albums / '
+          f'{N_ALBUMS * TRACKS_PER_ALBUM} items): ok')
+
+
+def test_kill_minus_9_mid_decision_recovery():
+    """#12 scope 5: SIGKILL the server while a decision is blocked, restart
+    against the same BEETSDIR, and confirm: state.pickle resume still works
+    (should_resume asks), nothing was half-imported, and /jobs/current
+    correctly reports no running job on the fresh process. (The issue text
+    names this endpoint /import/current; the actual route — shared across
+    import/convert/artwork/sync jobs — is /jobs/current, see server.py.)
+
+    This goes further than the existing graceful-abort resume test (see
+    main(), bullet 7): terminate()/wait() there gives the process a chance
+    to run its finally-blocks, SIGKILL here gives it none.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix='beetsgui-kill9-'))
+    beetsdir = tmp / 'beets'
+    beetsdir.mkdir()
+    plugindir = beetsdir / 'plugins'
+    plugindir.mkdir()
+    (plugindir / 'stubsource.py').write_text(STUB_PLUGIN)
+    (beetsdir / 'config.yaml').write_text(
+        f'directory: {tmp / "library"}\n'
+        f'library: {beetsdir / "library.db"}\n'
+        f'pluginpath: [{plugindir}]\n'
+        'plugins: [stubsource]\n'
+        'import:\n'
+        '    resume: ask\n'
+        '    copy: yes\n'
+        '    write: no\n'
+    )
+    src = tmp / 'incoming'
+    make_album(src / 'a', 'Kill Artist', 'Kill Album A', ['One'])
+    make_album(src / 'b', 'Kill Artist', 'Kill Album B', ['One'])
+
+    proc = start_server(beetsdir)
+    try:
+        stream = run(src)
+        reached_decision = False
+        for event in stream:
+            if event['type'] == 'decision':
+                reached_decision = True
+                # Kill -9 right here: a decision is blocked mid-task, the
+                # importer thread is parked in ImportJob.ask(), and beets'
+                # state.pickle write for a *finished* album (if any ran
+                # before this one) has already landed or not — either way,
+                # nothing gets a chance to clean up.
+                proc.kill()
+                proc.wait(timeout=10)
+                break
+        assert reached_decision, 'never reached a decision to kill against'
+    finally:
+        pass  # proc is already dead; stop_server would hang polling /status
+
+    for _ in range(50):
+        try:
+            urllib.request.urlopen(f'{BASE}/status', timeout=1).read()
+            time.sleep(0.2)
+        except Exception:
+            break
+
+    # Restart against the same BEETSDIR.
+    proc = start_server(beetsdir)
+    try:
+        with urllib.request.urlopen(f'{BASE}/jobs/current', timeout=5) as r:
+            cur = json.load(r)
+        assert cur['ok'] and cur.get('id') is None, \
+            f'a fresh process must report no running job after a kill -9: {cur}'
+
+        before = albums_in(beetsdir)
+        assert ('Kill Artist', 'Kill Album A') not in before or \
+               ('Kill Artist', 'Kill Album B') not in before, \
+            'both albums landing means nothing was actually interrupted'
+
+        # Resume: the killed run left state.pickle with progress (if any
+        # album finished before the kill) or nothing at all — either way
+        # this must not crash, and re-importing must not duplicate an
+        # album that already finished.
+        resumed_kinds = []
+        for event in run(src):
+            if event['type'] != 'decision':
+                continue
+            resumed_kinds.append(event['kind'])
+            if event['kind'] == 'resume':
+                decide(event, choice='resume')
+            else:
+                decide(event, choice='asis')
+        after = albums_in(beetsdir)
+        assert ('Kill Artist', 'Kill Album A') in after
+        assert ('Kill Artist', 'Kill Album B') in after
+        # No duplicate rows for either album.
+        assert after.count(('Kill Artist', 'Kill Album A')) == 1, after
+        assert after.count(('Kill Artist', 'Kill Album B')) == 1, after
+    finally:
+        stop_server(proc)
+        shutil.rmtree(tmp, ignore_errors=True)
+    print('kill -9 mid-decision recovery: ok')
+
+
 if __name__ == '__main__':
     main()
+    test_quality_rank_real_encoders()
+    test_unicode_and_edge_case_metadata()
+    test_shell_metacharacter_and_space_paths()
+    test_missing_ffmpeg_dependency()
+    test_scale_library_endpoints()
+    test_kill_minus_9_mid_decision_recovery()
+    print('all #12 stress/correctness checks passed')

--- a/test_libops.py
+++ b/test_libops.py
@@ -17,7 +17,31 @@ from beets.ui import UserError
 import libops
 
 
+def test_split_query_apostrophes():
+    """An apostrophe is a letter here, not an unclosed quote (#12).
+
+    shlex reads `Don't` as the start of a quoted string and raises, which
+    used to surface as a 400 from /library?q= — for a search term that is
+    entirely ordinary in a music library. Balanced quoting still has to keep
+    working, because that is what the UI itself generates.
+    """
+    for q, expected in [
+        ("O'Brien", ["O'Brien"]),
+        ("Don't Stop", ["Don't", 'Stop']),
+        ("Guns N' Roses", ['Guns', "N'", 'Roses']),
+        ("artist:O'Brien year:2020..", ["artist:O'Brien", 'year:2020..']),
+        # What the UI compiles is balanced and must be unquoted, not split.
+        ("artist:'it'\\''s here'", ['artist:it\'s here']),
+        ('album:"a quoted bit"', ['album:a quoted bit']),
+        ('', []),
+    ]:
+        assert libops.split_query(q) == expected, (
+            f'split_query({q!r}) == {libops.split_query(q)!r}, want {expected!r}')
+
+
 def main():
+    test_split_query_apostrophes()
+
     libops.get_library = lambda: (_ for _ in ()).throw(
         AssertionError('should not reach the library'))
 

--- a/test_libops.py
+++ b/test_libops.py
@@ -12,9 +12,33 @@ reached, rather than just asserting the (still-empty) result.
 
 Run: ~/.local/pipx/venvs/beets/bin/python test_libops.py
 """
+import re
+from pathlib import Path
+
+from beets.library import Item
 from beets.ui import UserError
 
 import libops
+
+HTML = Path(__file__).parent / 'beetsgui.html'
+
+
+def test_export_format_presets_use_real_fields():
+    """Every Library-tab format preset must name fields beets actually has
+    (#12). `$key` isn't one — the real field is `$initial_key` — so that
+    preset silently rendered an empty string for every track. render_format()
+    doesn't validate (a typo'd field renders blank, same as `beet ls -f`
+    would), so nothing else would have caught this; only checking the
+    literal preset strings does.
+    """
+    presets = re.findall(r"setFormat\('([^']*)'\)", HTML.read_text())
+    assert len(presets) >= 4, 'expected at least the 4 known format presets'
+    known = Item.all_keys()
+    for preset in presets:
+        for field in re.findall(r'\$(\w+)', preset):
+            assert field in known, (
+                f'preset {preset!r} references ${field}, which is not a '
+                f'real beets field')
 
 
 def test_split_query_apostrophes():
@@ -40,6 +64,7 @@ def test_split_query_apostrophes():
 
 
 def main():
+    test_export_format_presets_use_real_fields()
     test_split_query_apostrophes()
 
     libops.get_library = lambda: (_ for _ in ()).throw(

--- a/test_smoke.py
+++ b/test_smoke.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Browser smoke test — drives the real UI in a real (headless) browser (#12).
+
+Every other test here calls the HTTP API directly. None of them would have
+caught today's two live-verified UI bugs: the Command box producing a
+`beet ls -f "..."` string that a shell mangles to nothing, and the BPM+Key
+export preset referencing `$key`, a field that doesn't exist, which
+silently rendered blank. Both were only visible by actually clicking the
+button and reading the file it wrote.
+
+Uses Playwright (`pipx inject beets playwright && playwright install
+chromium`) against the same start_server()/stop_server() throwaway-BEETSDIR
+harness as test_importsession.py — never the real library.
+
+Run: ~/.local/pipx/venvs/beets/bin/python test_smoke.py
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+sys.path.insert(0, str(Path(__file__).parent))
+from test_importsession import (BASE, STUB_PLUGIN, decide, events, make_album,
+                                 post, run, start_server, stop_server)
+
+
+def _make_track_with_bpm_key(path, artist, album, title, bpm, key):
+    """Like test_importsession.make_track, plus real BPM/key tags — needed
+    to actually exercise the BPM+Key export preset (#12): mediafile only
+    reads FLAC's initial_key from the literal `INITIALKEY` Vorbis comment,
+    confirmed by writing then reading one back before trusting this."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run([
+        'ffmpeg', '-loglevel', 'error', '-y',
+        '-f', 'lavfi', '-i', 'anullsrc=r=44100:cl=mono', '-t', '1',
+        '-metadata', f'artist={artist}', '-metadata', f'album={album}',
+        '-metadata', f'title={title}', '-metadata', 'track=1',
+        '-metadata', f'bpm={bpm}', '-metadata', f'INITIALKEY={key}',
+        str(path),
+    ], check=True)
+
+
+def _setup():
+    tmp = Path(tempfile.mkdtemp(prefix='beetsgui-smoke-'))
+    beetsdir = tmp / 'beets'
+    beetsdir.mkdir()
+    plugindir = beetsdir / 'plugins'
+    plugindir.mkdir()
+    (plugindir / 'stubsource.py').write_text(STUB_PLUGIN)
+    (beetsdir / 'config.yaml').write_text(
+        f'directory: {tmp / "library"}\n'
+        f'library: {beetsdir / "library.db"}\n'
+        f'pluginpath: [{plugindir}]\n'
+        'plugins: [stubsource]\n'
+        'import:\n    resume: ask\n    copy: yes\n    write: no\n')
+    return tmp, beetsdir
+
+
+def _import_one_album(tmp):
+    """Populate the library through the real import pipeline (not raw SQL) —
+    the smoke test should see what an actual user's library looks like."""
+    src = tmp / 'incoming'
+    make_album(src / 'one', "Sinéad O'Brien", 'Smoke Test Album', ['Alpha', 'Beta'])
+    for event in run(src / 'one'):
+        if event['type'] == 'decision':
+            decide(event, choice='asis')
+
+    # A second, singleton track with real BPM/key tags — make_album's
+    # fixtures never set either, so BPM+Key would render blank whether the
+    # preset's field names are right or wrong. This track exists so the
+    # export assertions below can tell the difference.
+    _make_track_with_bpm_key(src / 'two' / '01 Keyed.flac',
+                             'BPM Test Artist', 'Keyed Album', 'Keyed', 126, '8A')
+    for event in run(src / 'two', singleton=True):
+        if event['type'] == 'decision':
+            decide(event, choice='asis')
+
+
+def main():
+    if not shutil.which('ffmpeg'):
+        raise SystemExit('ffmpeg needed to generate test audio — skipping')
+
+    tmp, beetsdir = _setup()
+    proc = start_server(beetsdir)
+    errors = []
+
+    try:
+        _import_one_album(tmp)
+
+        with sync_playwright() as pw:
+            browser = pw.chromium.launch()
+            page = browser.new_page()
+            page.on('console', lambda m: errors.append(m.text) if m.type == 'error' else None)
+            page.on('pageerror', lambda e: errors.append(str(e)))
+
+            page.goto(BASE, wait_until='networkidle')
+            assert page.locator('text=BeetsGUI').first.is_visible()
+
+            tab_btn = lambda name: page.locator('.tab-btn', has_text=name)
+
+            # Every tab switches and renders without a JS error.
+            for tab in ('Library', 'Export', 'Recover', 'Inbox'):
+                tab_btn(tab).click()
+                page.wait_for_timeout(150)
+            assert not errors, f'console errors while switching tabs: {errors}'
+
+            # Library tab shows the album that was actually just imported —
+            # end to end: real import -> real library.db -> real /library
+            # query -> real DOM.
+            tab_btn('Library').click()
+            page.wait_for_timeout(300)
+            assert page.locator('text=Smoke Test Album').first.is_visible(), \
+                'imported album never appeared in the Library tab'
+
+            # Apostrophe search through the real filter UI (#12): type a
+            # condition, not just hit the API directly.
+            page.get_by_role('button', name='+ Add condition').click()
+            page.locator('.f-field').first.fill('artist')
+            page.locator('.f-value').first.fill("O'Brien")
+            page.wait_for_timeout(400)
+            assert page.locator('text=Smoke Test Album').first.is_visible(), \
+                "apostrophe filter (artist:O'Brien) found nothing in the UI"
+            assert not errors, f'console errors after apostrophe filter: {errors}'
+
+            # Clear the filter row before exporting, so export sees the
+            # whole (one-album) library rather than the filtered subset —
+            # keeps this test's export-count assertion independent of the
+            # filter test above.
+            clear_btn = page.locator('#filter-clear')
+            if clear_btn.is_visible():
+                clear_btn.click()
+                page.wait_for_timeout(200)
+
+            # Export via the real preset button and the real Export button,
+            # into a throwaway file — typing a format string by hand would
+            # miss the actual bug found live in this issue: the "BPM + Key"
+            # preset referenced a field ($key) that doesn't exist, and
+            # silently rendered blank. Only clicking the button and reading
+            # the written file catches that, so this does exactly that.
+            dest = tmp / 'export.txt'
+            page.locator('#tab-library').get_by_role('button', name='BPM + Key', exact=True).click()
+            page.locator('#lib-export-dest').fill(str(dest))
+            page.locator('#tab-library').get_by_role('button', name='Export', exact=True).click()
+            page.wait_for_timeout(400)
+            assert dest.exists(), 'Export button did not write the destination file'
+            content = dest.read_text()
+            assert 'Alpha' in content and 'Beta' in content, content
+            assert 'BPM Test Artist' in content, content
+            assert 'BPM: 126' in content, f'BPM field did not render:\n{content}'
+            # beets normalises the key string (8A -> 8a); rendering *some*
+            # non-empty value is what the field-name bug actually breaks.
+            assert 'key: 8a' in content.lower(), (
+                f'Key field did not render — the preset likely references a '
+                f'field beets does not have:\n{content}')
+            assert not errors, f'console errors during export: {errors}'
+
+            # The Origin the browser actually sends must pass the #12 guard
+            # — this is what a curl-based check cannot prove.
+            result = page.evaluate('''
+                fetch('/library/count', {method:'POST',
+                    headers:{'Content-Type':'application/json'},
+                    body: JSON.stringify({scope:{query:''}})
+                }).then(r => r.status)
+            ''')
+            assert result == 200, f'same-origin POST from the real page got {result}'
+
+            browser.close()
+
+        with urllib.request.urlopen(f'{BASE}/jobs/current', timeout=10) as r:
+            cur = json.load(r)
+        assert cur['ok'] and cur.get('id') is None, cur
+    finally:
+        stop_server(proc)
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    print('browser smoke test: all tabs render, apostrophe search works, '
+          'export writes real fields, same-origin POST passes the CSRF guard - ok')
+
+
+if __name__ == '__main__':
+    main()

--- a/traktor.py
+++ b/traktor.py
@@ -152,8 +152,8 @@ def request_download(path):
 # ── Source discovery and classification ───────────────────────────────────
 
 def find_sources(roots):
-    """Every .nml/.m3u under `roots`. stdlib walk, so no `fd` dependency for
-    a core feature (the README only requires fd for the Inbox utilities)."""
+    """Every .nml/.m3u under `roots`. stdlib walk, like every other scan
+    here — nothing in this app shells out to `fd`."""
     found = []
     for root in roots:
         root = os.path.expanduser(root)


### PR DESCRIPTION
## Summary

Fixes everything issue #12's live stress test at 5,000 albums / 40,000 items / 2,200 real encoded files turned up, plus one CSRF gap that three earlier audit passes (#11, #27, #38) had incorrectly closed.

- **Shell-quoting**: the Library tab's format presets were broken by their own double-quoting (`-f "$artist..."` → shell expands to nothing), and the same missing quoting let a filter value of `$(...)` or a bare `;` run when the generated command was pasted. Fixed with a real POSIX `shellQuote()`, verified against a real `bash`.
- **Apostrophe search**: `/library?q=` 400'd on any name with an odd quote count — `O'Brien`, `Don't Stop`, `Guns N' Roses`. `split_query()` now falls back to a plain split instead of erroring.
- **`/info/stats` latency**: 2,808ms → 16ms at 40k tracks (one SQL aggregate instead of walking every ORM item) — this sits on every page load via the first-run banner, not just the Stats panel.
- **CSRF**: a cross-site POST with `Content-Type: text/plain` gets no preflight and no `Origin` check existed, so `/import/start`'s missing-path handling (`[None]` isn't an empty list) let a visited page start an import of the server's own working directory. Added an Origin guard beside the existing Host guard, verified live in a real browser that the app's own requests still pass.
- **Command box deleted** — the last copy-paste-into-terminal surface in the app. Its one real capability (template-formatted export, e.g. BPM+Key) is now a native `/library/export` endpoint using the same beets template engine `preview_modify` already uses, no shell involved.
- **Browser smoke test added** (`test_smoke.py`, Playwright) — the UI layer had zero test coverage; every other test drives the HTTP API directly. Caught a real bug during development (BPM+Key preset referenced `$key`, not a real beets field, silently blank) that no API-level test could have seen.
- **Docs**: stale `/import/current` → `/jobs/current` (shared across every job type, not import-specific), stale `fd` requirement removed (nothing shells out to it), new `CLAUDE.md` capturing the architecture essentials this session had to (re)derive.

Closes #12.

## Test plan
- [x] All 11 suites pass (`test_filter`, `test_queue`, `test_libops`, `test_scope`, `test_playback`, `test_transcode`, `test_usb_mirror`, `test_jobs`, `test_traktor`, `test_importsession`, `test_smoke`)
- [x] `/library` search latency measured live at 5,000 albums / 40,000 items — all endpoints under the 1s target
- [x] CSRF guard verified in a real headless browser: cross-site POST → 403, same-origin POST → 200
- [x] `test_smoke.py`'s BPM+Key assertion confirmed to fail when `$key` is reintroduced, then reverted