### PR TITLE
Fix silent misdirection to real ~/.config/beets after beets 2.13 migration noise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,18 @@ Local web app for [beets](https://beets.io) as a Safari Web App on macOS.
 `server.py` (Flask, port 1612) + `beetsgui.html` (single file, no build
 step, no npm). Never assume a build/bundle step exists — there isn't one.
 
+## Local beets version must match CI's pin (#47)
+
+CI (`.github/workflows/test.yml`) pins `beets==2.13.1` deliberately — "a red
+run here should mean this PR broke something, not beets shipped a new
+release." Check your local install matches before trusting any local test
+result: `pipx runpip beets show beets`. This bit hard once already: an
+entire session's worth of local "all green" runs were against beets 2.11.0,
+and merging on that basis shipped a real bug (#12/config-path, below) that
+only exists on 2.13+. If a local run and CI disagree, assume the version
+mismatch first, not a flaky test. To reinstall the pinned version:
+`pipx runpip beets install beets==2.13.1`.
+
 ## Non-negotiable safety rule
 
 **Never point a test, a script, or an experiment at `~/.config/beets` or
@@ -72,26 +84,51 @@ shared across every job type, not import-specific — the route names don't
 say "import" despite older docs (including README, before this session)
 sometimes calling them that.
 
-## A trap that already bit once here
+## `get_config_path()`/`get_library_db_path()`/`get_library_directory()` cache only on success (#12)
 
-Some endpoint URLs in `beetsgui.html` are built by string concatenation
-(e.g. `'/library/'+kind` in `runMaint()`), not written as a literal.
-`git log -S'/library/write'` or a plain grep for the literal route string
-will report "never referenced" even when a real button calls it — this
-produced a wrong dead-code finding in this session's own audit. Trace the
-actual call sites (read the onclick handler through to the fetch/postJSON
-call) before concluding something is unused.
+beets >= 2.13 can run a one-time schema migration as a side effect of *any*
+`beet` invocation against a library that hasn't been opened this way before
+— including a brand-new one, so this fires on every fresh beetsGUI install's
+first request. It prints `Created database backup at: ...` lines to
+**stdout**, ahead of the path `beet config --path` actually returns. These
+three functions are `@functools.lru_cache`d for the process's life (avoids
+a ~700ms `beet` subprocess per request) — if you ever touch them, the
+non-negotiable invariant is that a *failed* resolution must never be
+cached, only a genuinely successful one, or one noisy first call
+permanently misdirects every `/library`-family read to `~/.config/beets` —
+the user's real library — for the rest of the server's life, silently
+(`ok: true`, empty results, no error). See `test_config_path.py` for the
+mocked reproduction; it doesn't depend on real migration timing.
+
+## Traps that already bit once here
+
+- Some endpoint URLs in `beetsgui.html` are built by string concatenation
+  (e.g. `'/library/'+kind` in `runMaint()`), not written as a literal.
+  `git log -S'/library/write'` or a plain grep for the literal route string
+  will report "never referenced" even when a real button calls it — this
+  produced a wrong dead-code finding in this session's own audit. Trace the
+  actual call sites (read the onclick handler through to the fetch/postJSON
+  call) before concluding something is unused.
+- A local test suite that's all green proves nothing if it ran against the
+  wrong beets version — see the pin note above. This shipped a real bug to
+  `master` for about 20 minutes before CI caught it.
 
 ## Testing
 
-11 suites, all `test_*.py` at repo root, each runnable standalone:
+12 suites, all `test_*.py` at repo root, each runnable standalone:
 `~/.local/pipx/venvs/beets/bin/python test_<name>.py`. Most need `ffmpeg`
-on PATH. `test_smoke.py` drives a real headless Chromium via Playwright
+on PATH; check your beets version matches CI's pin first (see above).
+`test_smoke.py` drives a real headless Chromium via Playwright
 (`pipx inject beets playwright && playwright install chromium`) — it's the
 only one that exercises `beetsgui.html`'s actual DOM/JS rather than the
 HTTP API, and it has already caught a bug (a format preset referencing a
 field that doesn't exist) that every API-level test missed. If you touch
 UI behavior, extend this one, not just the API-level tests.
+
+CI only runs `test_importsession.py`/`test_transcode.py`/`test_jobs.py`/
+`test_playback.py` (`.github/workflows/test.yml`) — the other 8, including
+`test_smoke.py`, are local-only. A change that only breaks one of those
+won't go red in CI; run the full set locally before trusting a PR.
 
 No `fd` or `xld` dependency — both were removed from what the app actually
 calls; don't reintroduce a shell-out to either without a documented reason.

--- a/server.py
+++ b/server.py
@@ -188,60 +188,96 @@ def list_volumes() -> list:
 
 
 @functools.lru_cache(maxsize=1)
+def _resolve_config_path() -> str:
+    """The real work behind get_config_path() — raises on any failure so
+    lru_cache never remembers a bad answer (see get_config_path() for why
+    that matters). Only a path this function actually returns is trusted
+    enough to cache for the process's lifetime.
+    """
+    r = subprocess.run(
+        [find_beet(), 'config', '--path'],
+        capture_output=True, text=True, timeout=5
+    )
+    # beets >= 2.13 can run one-time schema migrations as a side effect of
+    # ANY invocation against a library that hasn't been opened this way
+    # before (including a brand-new one — every fresh beetsGUI install hits
+    # this on its very first request) — and prints "Created database
+    # backup at: ..." lines to *stdout*, not stderr, ahead of the path.
+    # `.strip()` alone doesn't drop them; take the first line only, and
+    # verify it's a real file before trusting it (#12).
+    lines = r.stdout.splitlines()
+    path = lines[0].strip() if lines else ''
+    if r.returncode != 0 or not path or not os.path.isfile(path):
+        raise RuntimeError(
+            f'beet config --path did not return a usable path: '
+            f'rc={r.returncode} stdout={r.stdout!r} stderr={r.stderr!r}')
+    return path
+
+
 def get_config_path() -> str:
     """Find the beets config file via 'beet config --path'.
 
-    Cached for the life of the process: this used to shell out on every
-    /library request (~700ms measured — `beet` is a Python CLI wrapper that
-    imports the whole beets package plus every enabled plugin on each
-    invocation), which dwarfed the actual query time (~6ms) by two orders
-    of magnitude. The config path doesn't move while this server is
-    running, same assumption `importsession.get_library()` already makes
-    about the Library object itself.
+    The successful result is cached for the life of the process: this used
+    to shell out on every /library request (~700ms measured — `beet` is a
+    Python CLI wrapper that imports the whole beets package plus every
+    enabled plugin on each invocation), which dwarfed the actual query time
+    (~6ms) by two orders of magnitude. The config path doesn't move while
+    this server is running, same assumption `importsession.get_library()`
+    already makes about the Library object itself.
+
+    A *failed* resolution is deliberately never cached (see
+    _resolve_config_path()) — retried on every call instead, at the ~700ms
+    cost, until it succeeds. The alternative (this app's actual behavior
+    until #12 found it live) is worse: one noisy first call permanently
+    misdirects every /library-family read to ~/.config/beets — the user's
+    real library — for the rest of the server's life, with no error, just
+    quietly wrong or empty results.
     """
     try:
-        r = subprocess.run(
-            [find_beet(), 'config', '--path'],
-            capture_output=True, text=True, timeout=5
-        )
-        if r.returncode == 0:
-            return r.stdout.strip()
+        return _resolve_config_path()
     except Exception:
-        pass
-    return os.path.expanduser('~/.config/beets/config.yaml')
+        return os.path.expanduser('~/.config/beets/config.yaml')
 
 
-@functools.lru_cache(maxsize=1)
+@functools.lru_cache(maxsize=2)  # two keys read this way: library, directory
+def _resolve_config_key(key: str) -> str:
+    """A top-level `key: value` line from config.yaml — raises on failure,
+    same contract as _resolve_config_path() and for the same reason: this
+    reads *through* _resolve_config_path() directly, never through
+    get_config_path()'s swallowed fallback, so a config.yaml that hasn't
+    resolved correctly yet can't get misread as `~/.config/beets/config.yaml`
+    (which may well exist, parse fine, and contain a real — but wrong —
+    `library:`/`directory:` line of its own) and have *that* wrong answer
+    cached forever by this function's own lru_cache.
+    """
+    config_path = _resolve_config_path()
+    for line in Path(config_path).read_text().splitlines():
+        m = re.match(rf'^{key}:\s*(.+)$', line.strip())
+        if m:
+            return os.path.expanduser(m.group(1).strip().strip('\'"'))
+    raise ValueError(f'no {key}: key in {config_path}')
+
+
 def get_library_db_path() -> str:
     """Find the beets library.db path from the 'library:' key in config.yaml.
 
-    Cached alongside get_config_path() for the same reason — same process
-    lifetime, same "doesn't move while we're running" assumption.
+    Retried until _resolve_config_key() actually succeeds, same as
+    get_config_path() — see that docstring for why a failure must never be
+    cached here.
     """
-    config_path = get_config_path()
     try:
-        for line in Path(config_path).read_text().splitlines():
-            m = re.match(r'^library:\s*(.+)$', line.strip())
-            if m:
-                return os.path.expanduser(m.group(1).strip().strip('\'"'))
+        return _resolve_config_key('library')
     except Exception:
-        pass
-    return os.path.expanduser('~/.config/beets/library.db')
+        return os.path.expanduser('~/.config/beets/library.db')
 
 
-@functools.lru_cache(maxsize=1)
 def get_library_directory() -> str:
     """The beets `directory:` key from config.yaml — same parse as
     get_library_db_path(), same cache lifetime assumption."""
-    config_path = get_config_path()
     try:
-        for line in Path(config_path).read_text().splitlines():
-            m = re.match(r'^directory:\s*(.+)$', line.strip())
-            if m:
-                return os.path.expanduser(m.group(1).strip().strip('\'"'))
+        return _resolve_config_key('directory')
     except Exception:
-        pass
-    return os.path.expanduser('~/Music')
+        return os.path.expanduser('~/Music')
 
 
 def resolve_item_path(raw) -> str:

--- a/test_config_path.py
+++ b/test_config_path.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Unit test for the config-path resolvers in server.py (#12).
+
+beets >= 2.13 can run a one-time schema migration as a side effect of ANY
+`beet` invocation against a library that hasn't been opened this way before
+— including a brand-new one, so this hits every fresh beetsGUI install on
+its very first request. It prints "Created database backup at: ..." lines
+to *stdout*, ahead of the actual path `beet config --path` returns.
+
+_resolve_config_path() used to do `r.stdout.strip()` and trust the whole
+multi-line result as a path. That "path" doesn't exist on disk, so
+get_library_db_path()/get_library_directory() silently fell through to
+their hardcoded defaults — `~/.config/beets/library.db`, the user's real
+library — and because all three functions were `@functools.lru_cache`d
+with no distinction between a real answer and a fallback, that wrong
+answer stuck for the rest of the server's life. Confirmed live: with
+`/unimported` (which is what triggers the first `get_library_db_path()`
+call in the Inbox tab's normal first-use flow) called before any import,
+every subsequent `/library` search silently searched the wrong database
+and reported zero results, `ok: true`, no error.
+
+Run: ~/.local/pipx/venvs/beets/bin/python test_config_path.py
+"""
+import subprocess
+from unittest import mock
+
+import server
+
+
+def _reset_caches():
+    server._resolve_config_path.cache_clear()
+    server._resolve_config_key.cache_clear()
+
+
+def _fake_run(stdout, returncode=0):
+    return mock.Mock(stdout=stdout, stderr='', returncode=returncode)
+
+
+def test_migration_noise_on_stdout_is_stripped(tmp_config):
+    """The path is always the first line; trailing migration/backup notices
+    on later lines must not become part of it."""
+    _reset_caches()
+    noisy = (f'{tmp_config}\n'
+             "Created database backup at: '/tmp/x/library.db-before-y.bak'.\n"
+             "Created database backup at: '/tmp/x/library.db-before-z.bak'.\n")
+    with mock.patch('server.subprocess.run', return_value=_fake_run(noisy)):
+        assert server.get_config_path() == str(tmp_config)
+
+
+def test_unusable_output_is_not_cached_as_success(tmp_path):
+    """A failed resolution (non-existent 'path', non-zero exit, empty
+    stdout) must be retried on the next call, not remembered forever — the
+    whole point of this fix. Simulated here as: first call fails, second
+    call (as if the transient cause had cleared) succeeds.
+    """
+    _reset_caches()
+    good = tmp_path / 'config.yaml'
+    good.write_text('directory: ~/Music\nlibrary: ~/Music/library.db\n')
+
+    calls = [_fake_run('/does/not/exist/config.yaml\n'),  # first: unusable
+             _fake_run(f'{good}\n')]                        # second: real
+    with mock.patch('server.subprocess.run', side_effect=calls):
+        first = server.get_config_path()
+        second = server.get_config_path()
+
+    # The bug: first (bad) call would get cached and returned forever,
+    # so `second` would equal `first` instead of the real path.
+    assert first == str(server.Path('~/.config/beets/config.yaml').expanduser())
+    assert second == str(good), (
+        f'a failed resolution was cached — second call returned {second!r} '
+        f'instead of retrying and finding the real config')
+
+
+def test_library_db_path_reads_through_the_retrying_resolver(tmp_path):
+    """get_library_db_path() must not read a *different*, independently
+    parseable fallback config (~/.config/beets/config.yaml, which may well
+    exist and have its own real library: line) and cache that as if it
+    were correct — it has to go through the same retry-until-genuinely-
+    resolved path get_config_path() uses.
+    """
+    _reset_caches()
+    real = tmp_path / 'real' / 'config.yaml'
+    real.parent.mkdir()
+    real.write_text('directory: /throwaway/music\nlibrary: /throwaway/library.db\n')
+
+    calls = [_fake_run('garbage, not a real path\n'),  # unimported's first call
+             _fake_run(f'{real}\n')]                     # library's later call
+    with mock.patch('server.subprocess.run', side_effect=calls):
+        first = server.get_library_db_path()   # sees the bug's failure mode
+        second = server.get_library_db_path()   # must retry, not reuse `first`
+
+    assert second == '/throwaway/library.db', (
+        f'expected the real throwaway library.db, got {second!r} — '
+        f'a failed first call was cached as if it had succeeded')
+    assert first != second, (
+        'first call should have hit the (uncached, harmless) fallback, '
+        'not the same wrong value forever')
+
+
+def main():
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as d:
+        tmp_config = Path(d) / 'config.yaml'
+        tmp_config.write_text('directory: ~/Music\nlibrary: ~/Music/library.db\n')
+        test_migration_noise_on_stdout_is_stripped(tmp_config)
+
+    with tempfile.TemporaryDirectory() as d:
+        test_unusable_output_is_not_cached_as_success(Path(d))
+
+    with tempfile.TemporaryDirectory() as d:
+        test_library_db_path_reads_through_the_retrying_resolver(Path(d))
+
+    _reset_caches()
+    print('ok')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

CI caught this within minutes of merging #82 — a genuinely serious latent bug that had nothing to do with the PR itself, and everything to do with local dev running beets 2.11.0 while CI/production is pinned to 2.13.1 (#47).

**Root cause**: beets >= 2.13 runs a one-time schema migration as a side effect of *any* `beet` invocation against a library that hasn't been opened this way before — including a brand-new one, so this fires on **every fresh beetsGUI install's first request**, not just version upgrades. It prints `Created database backup at: ...` lines to stdout, ahead of the actual path `beet config --path` returns.

`get_config_path()` did `r.stdout.strip()` and trusted the entire multi-line result as the path. That "path" doesn't exist on disk, so `get_library_db_path()`/`get_library_directory()` silently fell through to their hardcoded defaults — **`~/.config/beets/library.db`, the user's real library**, not whatever the app is actually configured against. All three functions were `@functools.lru_cache`d with no distinction between a real answer and a fallback, so the wrong answer stuck **for the rest of the server's life**.

Confirmed live: with `/unimported` (the Inbox tab's first real action for a new user) called before any import, every subsequent `/library` search silently searched the wrong database and reported zero results — `ok: true`, no error, nothing a user would notice.

**Fix**: only cache a resolution that actually succeeded. The internal resolvers now raise on failure instead of returning a fallback — `lru_cache` never remembers an exception, so the next call retries at the ~700ms subprocess cost until it genuinely resolves, instead of caching a bad answer forever. Public function signatures/fallback behavior unchanged for callers.

## Test plan
- [x] `test_config_path.py` (new) — mocked `subprocess.run`, no real beets needed, deterministic
- [x] Falsified against the pre-fix code directly: confirmed the old `get_config_path()` really does return the multi-line garbage when fed noisy stdout
- [x] Full suite (12 files incl. `test_smoke.py`) passes against beets **2.13.1** (the pinned CI version, not what local dev had installed before this)
- [x] Live repro/fix verified: `/unimported` → import → `/library?q=...` now finds the track instead of silently querying the wrong database