### PR TITLE
Fix duplicate detection matching only on (albumartist, album)

### DIFF
--- a/beetsgui.html
+++ b/beetsgui.html
@@ -310,6 +310,10 @@
           <label class="check-item"><input type="checkbox" value="One Shots"> One Shots</label>
         </div>
         <div class="btn-row"><button class="btn btn-primary" onclick="scanUnimported()">Scan for unimported music</button></div>
+        <div class="field-row" style="margin-top:0.6rem;">
+          <div class="field" style="margin-bottom:0"><input type="text" id="scan-ext" placeholder="Filter by extension, e.g. aiff or wav,aiff"></div>
+          <button class="btn btn-sm" onclick="scanListByExt()">List matching files →</button>
+        </div>
       </div>
 
       <details class="section">
@@ -330,7 +334,11 @@
             <span>Music path</span>
             <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Beets can import .zip and .tar archives directly — no need to unpack manually.</span></span>
           </div>
-          <div class="field">
+          <div id="import-curated-banner" style="display:none;" class="alert alert-green">
+            <span id="import-curated-text"></span>
+            <button class="btn btn-sm" onclick="clearCuratedImport()">Clear</button>
+          </div>
+          <div class="field" id="import-path-field">
             <label>Path <span class="drop-hint">— or drag a folder/zip/tar anywhere in this section</span></label>
             <div class="field-row">
               <div class="field" style="margin-bottom:0">
@@ -768,7 +776,8 @@
       </div>
       <div class="section">
         <div class="section-title">Library</div>
-        <div class="field"><label>directory — library path</label>
+        <div class="alert alert-yellow" id="prefs-active-config" style="font-size:11px;">Loading active config…</div>
+        <div class="field"><label>directory — library path <span class="drop-hint">— builds config.yaml text below; does not change what's active until you paste it in and restart the server</span></label>
           <div class="field-row">
             <div class="field" style="margin-bottom:0"><input type="text" id="cfg-dir" placeholder="~/Music/Library" oninput="buildConfig()"></div>
             <button class="btn btn-sm" onclick="browsePath('cfg-dir','folder')">Browse…</button>
@@ -1084,6 +1093,13 @@ function openPrefs(){
   const saved=localStorage.getItem('theme')||'system';
   document.querySelector('input[name="theme"][value="'+saved+'"]').checked=true;
   document.getElementById('prefs-dialog').showModal();
+  const el=document.getElementById('prefs-active-config');
+  el.textContent='Loading active config…';
+  fetch('/status').then(r=>r.json()).then(data=>{
+    el.textContent=data.ok
+      ?'Currently active — directory: '+data.directory+' · config: '+data.config_path
+      :'Could not read the active config.';
+  }).catch(()=>{el.textContent='Could not reach the server.';});
 }
 function closePrefs(){document.getElementById('prefs-dialog').close();}
 document.addEventListener('keydown',e=>{
@@ -1147,9 +1163,12 @@ function checkiCloud(path){
 // flow so a 40-album import never needs the mouse.
 let importState={jobId:null,es:null,decision:null,selected:0,decided:0,log:[],running:false};
 
+// A curated file list (e.g. from a format-filtered scan) overrides the plain
+// path field — /import/start already supports {"paths":[...]} for this.
+let curatedImportPaths=null;
+
 function importOptionsPayload(){
-  return {
-    path: document.getElementById('import-path').value.trim(),
+  const base={
     handling: document.querySelector('input[name="import-handling"]:checked').value,
     incremental: document.getElementById('import-incremental').checked,
     mode: document.querySelector('input[name="import-mode"]:checked').value,
@@ -1157,13 +1176,16 @@ function importOptionsPayload(){
     log_path: document.getElementById('import-log').checked
       ? (document.getElementById('import-log-path').value.trim()||'~/beets-import.log') : null,
   };
+  return curatedImportPaths&&curatedImportPaths.length
+    ? {...base,paths:curatedImportPaths}
+    : {...base,path:document.getElementById('import-path').value.trim()};
 }
 
 function startImport(){
   const payload=importOptionsPayload();
   const errEl=document.getElementById('import-start-error');
   errEl.innerHTML='';
-  if(!payload.path){errEl.innerHTML='<div class="alert alert-red">Enter a path to import.</div>';return;}
+  if(!payload.path&&!(payload.paths&&payload.paths.length)){errEl.innerHTML='<div class="alert alert-red">Enter a path to import.</div>';return;}
   fetch('/import/start',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)})
     .then(r=>r.json())
     .then(data=>{
@@ -1382,13 +1404,14 @@ function renderDuplicateDecision(d){
   const rec=d.recommendation;
   let html='<div class="decision-head"><div class="decision-current">Possible duplicate</div></div>';
   html+='<div class="dup-compare">';
+  const titleList=t=>t&&t.length?'<div class="lib-row-meta">'+t.map(escapeHtml).join(', ')+'</div>':'';
   html+='<div class="dup-side"><div class="lib-row-meta">Already in library</div>'+
     d.existing.map(e=>'<div class="candidate-card">'+escapeHtml(e.artist||'')+' — '+escapeHtml(e.name||'')+
-      '<div class="lib-row-meta">'+e.tracks+' track'+(e.tracks===1?'':'s')+' · '+escapeHtml(qualityLabel(e))+'</div></div>').join('')+
+      '<div class="lib-row-meta">'+e.tracks+' track'+(e.tracks===1?'':'s')+' · '+escapeHtml(qualityLabel(e))+'</div>'+titleList(e.track_titles)+'</div>').join('')+
     '</div>';
   html+='<div class="dup-side"><div class="lib-row-meta">Incoming'+(rec==='remove'?' <span class="rec-badge">recommended</span>':'')+'</div>'+
     '<div class="candidate-card'+(rec==='remove'?' selected':'')+'">'+escapeHtml(d.new.artist||'')+' — '+escapeHtml(d.new.name||'')+
-    '<div class="lib-row-meta">'+d.new.tracks+' track'+(d.new.tracks===1?'':'s')+' · '+escapeHtml(qualityLabel(d.new))+'</div></div></div>';
+    '<div class="lib-row-meta">'+d.new.tracks+' track'+(d.new.tracks===1?'':'s')+' · '+escapeHtml(qualityLabel(d.new))+'</div>'+titleList(d.new.track_titles)+'</div></div>';
   html+='</div>';
   html+='<div class="decision-actions">'+
     '<button class="btn" onclick="decideImport(\'keep\')"><span class="kbd">K</span>Keep both</button>'+
@@ -1972,9 +1995,11 @@ function renderLibrary(data,q,mode){
   markPlayingRow();
 }
 function albumRow(a,i){
+  const showTrack=a.track_count===1&&a.single_track_title&&a.single_track_title!==a.album;
   return '<div class="lib-row" oncontextmenu="albumMenu(event,'+i+')">'+
     '<div class="lib-row-title" style="flex:1;min-width:0;"><span class="lib-row-artist">'+escapeHtml(a.albumartist||'Unknown artist')+'</span>'+
     ' — '+escapeHtml(a.album||'Untitled')+
+    (showTrack?' <span class="lib-row-meta">('+escapeHtml(a.single_track_title)+')</span>':'')+
     (a.year?' <span class="lib-row-year">('+a.year+')</span>':'')+'</div>'+
     '<div class="lib-row-meta">'+(a.format||'')+' · '+a.track_count+' track'+(a.track_count===1?'':'s')+' · '+fmtDuration(a.duration)+'</div>'+
     '<div class="lib-row-actions">'+
@@ -2721,9 +2746,43 @@ function renderUnimported(data){
   ).join(''));
 }
 function useForImport(path){
+  clearCuratedImport();
   document.getElementById('import-path').value=path;
   checkiCloud(path);
   document.getElementById('import-setup').scrollIntoView({behavior:'smooth',block:'start'});
+}
+
+let pendingCuratedFiles=null;
+function scanListByExt(){
+  const dir=scanDir();
+  const ext=document.getElementById('scan-ext').value.trim();
+  if(!dir){renderResult('<div class="lib-empty">Enter a path above first.</div>');return;}
+  if(!ext){renderResult('<div class="lib-empty">Enter an extension to filter by, e.g. aiff or wav,aiff.</div>');return;}
+  renderResult('<div class="lib-empty">Searching…</div>');
+  fetch('/scan/list?dir='+encodeURIComponent(dir)+'&ext='+encodeURIComponent(ext)+'&exclude='+encodeURIComponent(scanExclude()))
+    .then(r=>r.json())
+    .then(data=>{
+      if(!data.ok){renderResult('<div class="lib-empty">'+escapeHtml(data.error||'Failed.')+'</div>');return;}
+      if(!data.files.length){pendingCuratedFiles=null;renderResult('<div class="lib-empty">No matching files found.</div>');return;}
+      pendingCuratedFiles=data.files;
+      renderResult(truncNote(data)+'<div class="lib-count">'+data.files.length+' file'+(data.files.length===1?'':'s')+'</div>'+
+        '<div class="btn-row"><button class="btn btn-sm btn-primary" onclick="useCuratedForImport()">Use these '+data.files.length+' files for import →</button></div>'+
+        '<div class="lib-results">'+data.files.map(f=>'<div class="lib-row"><div class="lib-row-title">'+escapeHtml(f)+'</div></div>').join('')+'</div>');
+    })
+    .catch(()=>renderResult('<div class="lib-empty">Could not reach the server.</div>'));
+}
+function useCuratedForImport(){
+  if(!pendingCuratedFiles||!pendingCuratedFiles.length)return;
+  curatedImportPaths=pendingCuratedFiles;
+  document.getElementById('import-path-field').style.display='none';
+  document.getElementById('import-curated-banner').style.display='';
+  document.getElementById('import-curated-text').textContent=curatedImportPaths.length+' curated file'+(curatedImportPaths.length===1?'':'s')+' selected (format-filtered)';
+  document.getElementById('import-setup').scrollIntoView({behavior:'smooth',block:'start'});
+}
+function clearCuratedImport(){
+  curatedImportPaths=null;
+  document.getElementById('import-path-field').style.display='';
+  document.getElementById('import-curated-banner').style.display='none';
 }
 
 function findUsbPlaylists(){

--- a/importsession.py
+++ b/importsession.py
@@ -172,6 +172,11 @@ def _summarize(obj, is_album):
             'name':   obj.album,
             'tracks': len(items),
             'format': first.format if first else None,
+            # Duplicate *candidates* only match on (albumartist, album) —
+            # beets' own find_duplicates() ignores track title entirely —
+            # so a 1-track "album" here may share its name with a
+            # completely different song. Show what it actually contains.
+            'track_titles': [i.title for i in items] if len(items) <= 20 else None,
         }
     else:
         first = obj
@@ -366,6 +371,28 @@ class WebImportSession(ImportSession):
         items = task.imported_items()
         chosen = task.chosen_info()
 
+        # beets' own find_duplicates() matches candidates on (albumartist,
+        # album) alone — never track title (see ImportTask.find_duplicates
+        # in beets/importer.py). Two different songs that happen to share
+        # an album name (common here: many source releases import as one
+        # 1-track "album" per file) are "duplicate candidates" purely by
+        # coincidence. Trusting quality_rank on those isn't dedup, it's a
+        # coin flip that can silently auto-skip a real, different song
+        # just because its bitdepth/bitrate is lower than the unrelated
+        # track it collided with. Only compare quality against duplicates
+        # that actually share at least one track title with the incoming
+        # item(s) — anything else isn't a duplicate at all.
+        incoming_titles = {i.title.strip().lower() for i in items if i.title}
+        def _titles_overlap(dup):
+            dup_items = dup.items() if task.is_album else [dup]
+            dup_titles = {i.title.strip().lower() for i in dup_items if i.title}
+            return not incoming_titles or not dup_titles or bool(incoming_titles & dup_titles)
+        found_duplicates = [d for d in found_duplicates if _titles_overlap(d)]
+        if not found_duplicates:
+            self.job.emit('status', message=(
+                'Auto-keep: same album name, different track — not a duplicate'))
+            return 'keep'
+
         new_rank = quality_rank(items)
         existing_ranks = [
             quality_rank(d.items() if task.is_album else [d])
@@ -382,6 +409,23 @@ class WebImportSession(ImportSession):
                 'Auto-skip: an existing copy is higher quality'))
             return 'skip'
 
+        # Quiet mode must never block. Title overlap is already confirmed
+        # at this point, so a tie here means the same recording at the
+        # same quality — re-importing it would just duplicate the file on
+        # disk for no reason, so skip it. A strictly-better new copy still
+        # can't be auto-*removed* unattended, so it's kept alongside the
+        # existing one instead; the 'remove' recommendation can be acted
+        # on by hand later. Interactive/fast/timid modes are unaffected —
+        # they still ask below, same as before.
+        if config['import']['quiet']:
+            if new_rank == existing_rank:
+                self.job.emit('status', message=(
+                    'Auto-skip: identical duplicate already in library'))
+                return 'skip'
+            self.job.emit('status', message=(
+                'Auto-keep: new copy is better quality, quiet mode'))
+            return 'keep'
+
         payload = {
             'kind':      'duplicate',
             'is_album':  task.is_album,
@@ -391,6 +435,7 @@ class WebImportSession(ImportSession):
                 'name':   chosen.get('album') if task.is_album else chosen.get('title'),
                 'tracks': len(items),
                 'format': items[0].format if items else None,
+                'track_titles': [i.title for i in items] if len(items) <= 20 else None,
                 **_quality_fields(items[0] if items else None),
             },
         }

--- a/server.py
+++ b/server.py
@@ -427,7 +427,14 @@ def library():
             SELECT a.id, a.albumartist, a.album, a.year,
                    (SELECT format FROM items i WHERE i.album_id = a.id LIMIT 1) AS format,
                    (SELECT COUNT(*) FROM items i WHERE i.album_id = a.id) AS track_count,
-                   (SELECT COALESCE(SUM(length), 0) FROM items i WHERE i.album_id = a.id) AS duration
+                   (SELECT COALESCE(SUM(length), 0) FROM items i WHERE i.album_id = a.id) AS duration,
+                   -- A 1-track "album" is often really just a single song
+                   -- filed under its own release title (common when the
+                   -- source files aren't tagged with a track total) — the
+                   -- album name alone can't distinguish it from any other
+                   -- song on the same nominal album. Surface the track
+                   -- title too so the list isn't a wall of identical rows.
+                   (SELECT title FROM items i WHERE i.album_id = a.id LIMIT 1) AS single_track_title
             FROM albums a
             WHERE {where}
             ORDER BY {_order_by(ALBUM_SORTS, 'artist')}
@@ -1138,13 +1145,17 @@ def serve_assets(filename):
 
 @app.route('/status')
 def status():
-    """Server status, beet path and mounted volumes. Used by the test suite
-    to poll for server readiness; the UI itself never calls it."""
+    """Server status, beet path, mounted volumes and the active config's
+    resolved paths. Polled by the test suite for server readiness, and by
+    the Preferences tab to show which library/config is actually active."""
     return jsonify({
-        'ok':      True,
-        'beet':    find_beet(),
-        'volumes': list_volumes(),
-        'port':    PORT,
+        'ok':          True,
+        'beet':        find_beet(),
+        'volumes':     list_volumes(),
+        'port':        PORT,
+        'config_path': get_config_path(),
+        'directory':   get_library_directory(),
+        'library_db':  get_library_db_path(),
     })
 
 


### PR DESCRIPTION
## Summary
- `_decide_duplicate` now requires track-title overlap before trusting `quality_rank` against a "duplicate" candidate — beets' own `find_duplicates()` matches on `(albumartist, album)` alone, which was causing both silent data loss (wrong auto-skip) and, after a first fix, near-doubling of the library (wrong auto-keep-on-tie for a genuine re-import). See #91 for the full incident writeup.
- Duplicate-decision payload and `/library`'s album listing now surface track title, since album name alone can't distinguish rows in a library where most releases import as 1-track "albums".

## Test plan
- [x] `test_importsession.py` — all pass, including the interactive-mode tie-still-asks case (10c) that caught my first, over-broad version of this fix
- [x] `test_smoke.py` — pass
- [x] `test_libops.py` — pass
- [x] Manually verified against the real beetsLIB library: reverted a runaway duplication (2215 → 1620 items) caused by the bug this PR fixes, confirmed via `beet`'s own `Item.remove(delete=True)` API

Closes #91