### PR TITLE
AcoustID/chroma: fingerprint backfill, dry-run re-tag review, fingerprint-based dedup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         # run here should mean "this PR broke something," not "beets
         # shipped a new release." See .github/workflows/beets-canary.yml
         # for the latter.
-        run: pip install beets==2.13.1 flask playwright
+        run: pip install beets==2.13.1 flask playwright pyacoustid
 
       - name: Install Playwright's Chromium
         # --with-deps pulls the system libraries Chromium needs on a bare
@@ -70,6 +70,15 @@ jobs:
 
       - name: Run test_importsession.py
         run: python test_importsession.py
+
+      - name: Run test_fingerprint.py
+        run: python test_fingerprint.py
+
+      - name: Run test_dedup_fingerprint.py
+        run: python test_dedup_fingerprint.py
+
+      - name: Run test_retag.py
+        run: python test_retag.py
 
       - name: Run test_usb_mirror.py
         run: python test_usb_mirror.py

--- a/beetsgui.html
+++ b/beetsgui.html
@@ -554,6 +554,13 @@
             <button class="btn" onclick="startSync('bpsync')">Re-fetch from Beatport <span class="mono">(bpsync)</span></button>
             <button class="btn" onclick="showMissing()">Find tracks missing from albums <span class="mono">(missing)</span></button>
           </div>
+          <div class="btn-row">
+            <button class="btn" onclick="startFingerprint()">Compute fingerprints <span class="mono">(chroma)</span> <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Local audio fingerprint only — no network call. Backfills tracks imported before the chroma plugin was enabled, so duplicate detection can compare audio instead of just tags. Needs pyacoustid (pipx inject beets pyacoustid) and chroma enabled.</span></span></button>
+          </div>
+          <hr class="divider">
+          <div class="btn-row">
+            <button class="btn" onclick="startRetag()">Preview re-tag <span class="mono">(AcoustID + MusicBrainz)</span> <span class="tip-wrap"><i class="tip-icon" tabindex="0">ℹ</i><span class="tip-box">Dry-run only — proposes candidates for albums/tracks whose tags may be wrong (e.g. a record label sitting in the artist field), nothing is written until you accept a candidate. Network call per album/track — can be slow on a real library.</span></span></button>
+          </div>
         </div>
       </details>
 
@@ -941,6 +948,17 @@
         </div>
       </div>
       <hr class="divider">
+      <div class="section">
+        <div class="section-title">Duplicate detection</div>
+        <div class="alert alert-yellow" id="dedup-coverage" style="font-size:11px;">Loading…</div>
+        <div class="field-row">
+          <div class="field" style="max-width:160px;"><label>Fingerprint match threshold</label><input type="number" id="dedup-threshold" min="0.5" max="1" step="0.01"></div>
+          <button class="btn btn-sm" style="align-self:flex-end;" onclick="saveDedupThreshold()">Save</button>
+        </div>
+        <div class="drop-hint" style="margin-top:0.3rem;">How similar two tracks' local audio fingerprints (0–1) must be to count as the same recording during import duplicate detection — audio identity, not tags. Falls back to matching on track title when a fingerprint isn't available on either side.</div>
+        <div id="dedup-save-result"></div>
+      </div>
+      <hr class="divider">
       <div class="section-title" style="margin-bottom:0.5rem;">Note: beet version</div>
       <div class="alert alert-yellow" style="font-size:10px; margin-bottom:0.75rem;"><b>beet version</b> (not --plugins) shows active plugins.<br>Plugins only activate when listed under <span class="mono">plugins:</span> in config.yaml.<br>⚠ Never run <span class="mono">beet config -e</span> while the GUI is editing.</div>
       <div class="btn-row">
@@ -1100,6 +1118,33 @@ function openPrefs(){
       ?'Currently active — directory: '+data.directory+' · config: '+data.config_path
       :'Could not read the active config.';
   }).catch(()=>{el.textContent='Could not reach the server.';});
+  loadDedupSettings();
+}
+function loadDedupSettings(){
+  const cov=document.getElementById('dedup-coverage');
+  cov.textContent='Loading…';
+  fetch('/dedup/settings').then(r=>r.json()).then(data=>{
+    if(!data.ok){cov.textContent='Could not load duplicate-detection settings.';return;}
+    document.getElementById('dedup-threshold').value=data.dedup_fingerprint_threshold;
+    if(!data.chroma_available){
+      cov.className='alert alert-yellow';
+      cov.textContent='pyacoustid is not installed — duplicate detection falls back to title-matching only. pipx inject beets pyacoustid';
+    } else {
+      cov.className='alert alert-green';
+      cov.textContent=data.fingerprinted+' of '+data.total+' tracks fingerprinted'+
+        (data.fingerprinted<data.total?' — run "Compute fingerprints" under Library → Metadata to backfill the rest.':'.');
+    }
+  }).catch(()=>{cov.textContent='Could not reach the server.';});
+}
+function saveDedupThreshold(){
+  const el=document.getElementById('dedup-threshold');
+  const value=parseFloat(el.value);
+  const out=document.getElementById('dedup-save-result');
+  postJSON('/dedup/settings',{dedup_fingerprint_threshold:value}).then(data=>{
+    out.innerHTML=data.ok
+      ?'<div class="alert alert-green" style="font-size:10px;margin-top:0.3rem;">Saved.</div>'
+      :'<div class="alert alert-red" style="font-size:10px;margin-top:0.3rem;">'+escapeHtml(data.error||'Could not save.')+'</div>';
+  }).catch(()=>{out.innerHTML='<div class="alert alert-red" style="font-size:10px;margin-top:0.3rem;">Could not reach the server.</div>';});
 }
 function closePrefs(){document.getElementById('prefs-dialog').close();}
 document.addEventListener('keydown',e=>{
@@ -1405,8 +1450,11 @@ function renderDuplicateDecision(d){
   let html='<div class="decision-head"><div class="decision-current">Possible duplicate</div></div>';
   html+='<div class="dup-compare">';
   const titleList=t=>t&&t.length?'<div class="lib-row-meta">'+t.map(escapeHtml).join(', ')+'</div>':'';
+  const matchBadge=e=>e.matched_by==='fingerprint'
+    ?'<span class="rec-badge" title="Matched by comparing local audio fingerprints, not tags">🎵 audio match</span>'
+    :'<span class="lib-row-meta" title="No fingerprint on one or both sides — matched by track title instead">🏷 title match</span>';
   html+='<div class="dup-side"><div class="lib-row-meta">Already in library</div>'+
-    d.existing.map(e=>'<div class="candidate-card">'+escapeHtml(e.artist||'')+' — '+escapeHtml(e.name||'')+
+    d.existing.map(e=>'<div class="candidate-card">'+escapeHtml(e.artist||'')+' — '+escapeHtml(e.name||'')+' '+matchBadge(e)+
       '<div class="lib-row-meta">'+e.tracks+' track'+(e.tracks===1?'':'s')+' · '+escapeHtml(qualityLabel(e))+'</div>'+titleList(e.track_titles)+'</div>').join('')+
     '</div>';
   html+='<div class="dup-side"><div class="lib-row-meta">Incoming'+(rec==='remove'?' <span class="rec-badge">recommended</span>':'')+'</div>'+
@@ -1578,6 +1626,7 @@ function jobSummary(ev){
   // encoded (beets skips existing targets silently), so don't claim it.
   if(ev.sent!=null)parts.push(ev.sent+(ev.pretend?' previewed':' sent to the converter'));
   if(ev.skipped)parts.push(ev.skipped+' skipped');
+  if(ev.fingerprinted!=null)parts.push(ev.fingerprinted+' fingerprinted');
   // mbsync/bpsync report no counts at all (coarse-progress job, see
   // sync.py) — say so plainly rather than a misleading "nothing to do".
   const body=parts.length?parts.join(', ')+(ev.total!=null?' of '+ev.total:'')
@@ -1590,6 +1639,8 @@ function handleJobEvent(ev){
   if(ev.type==='status'){
     const status=document.getElementById('job-status');
     if(status)status.textContent=ev.message;
+  } else if(ev.type==='proposal'){
+    retagProposals.push(ev);
   } else if(ev.type==='error'){
     running.innerHTML='<div class="alert alert-red">'+escapeHtml(ev.message)+'</div>';
   } else if(ev.type==='done'){
@@ -1638,6 +1689,78 @@ function runArtwork(){
 }
 function startSync(kind){
   startJob('/sync/start',{kind:kind,...scopeBody()});
+}
+function startFingerprint(){
+  startJob('/fingerprint/start',scopeBody());
+}
+
+// ── Retag preview (#90) ──────────────────────────────────────────────────────
+// Proposals stream in via 'proposal' SSE events (handleJobEvent below) but
+// aren't rendered until the scan is done — the status line already shows
+// live progress (job-status, same as every other job), and rebuilding a
+// growing candidate list on every event would reset scroll position and
+// flicker mid-review. retagLastDoneEvent+retagProposals together are what
+// applyRetagCandidate() re-renders from after removing an applied one.
+let retagProposals=[];
+let retagLastDoneEvent=null;
+function startRetag(){
+  retagProposals=[];retagLastDoneEvent=null;
+  startJob('/retag/start',scopeBody(),renderRetagResult);
+}
+function retagSummaryHtml(ev){
+  if(!ev)return'';
+  const cls=ev.aborted?'alert-yellow':'alert-green';
+  const label=ev.aborted?'Aborted — ':'Scan finished — ';
+  let scanned='';
+  if(ev.albums_scanned!=null){
+    scanned=' (of '+ev.albums_scanned+' album'+(ev.albums_scanned===1?'':'s')+
+      (ev.items_scanned?' and '+ev.items_scanned+' singleton'+(ev.items_scanned===1?'':'s'):'')+' scanned)';
+  }
+  return '<div class="alert '+cls+'">'+label+retagProposals.length+' candidate'+(retagProposals.length===1?'':'s')+' to review'+scanned+'.</div>';
+}
+function renderRetagList(){
+  if(!retagProposals.length)return '<div class="lib-empty">No candidates left to review.</div>';
+  return retagProposals.map((p,pi)=>renderRetagProposal(p,pi)).join('');
+}
+function renderRetagResult(ev,el){
+  retagLastDoneEvent=ev;
+  el.innerHTML=retagSummaryHtml(ev)+renderRetagList();
+}
+function retagCandidateCard(c,ci,pi,cur,kind){
+  const curArtist=cur.artist,curTitle=kind==='album'?cur.album:cur.title;
+  const renamed=(c.tracks||[]).filter(t=>t.current!==t.new);
+  const trackNote=c.tracks&&c.tracks.length
+    ?c.tracks.length+' track'+(c.tracks.length===1?'':'s')+(renamed.length?', '+renamed.length+' renamed':'')
+    :'';
+  return '<div class="candidate-card">'+
+    '<div class="candidate-head">'+
+      '<span class="candidate-index">'+(ci+1)+'</span>'+
+      '<div class="candidate-title">'+fieldDiff(c.title,curTitle)+' <span class="lib-row-year">'+(c.year||'')+'</span></div>'+
+      '<div class="candidate-sim">'+c.similarity+'%</div>'+
+    '</div>'+
+    '<div class="candidate-artist">'+fieldDiff(c.artist,curArtist)+'</div>'+
+    '<div class="candidate-meta">'+[c.label,c.country,c.media,c.albumtype].filter(Boolean).map(escapeHtml).join(' · ')+'</div>'+
+    (trackNote?'<div class="lib-row-meta">'+trackNote+'</div>':'')+
+    '<button class="btn btn-primary btn-sm" onclick="applyRetagCandidate('+pi+','+ci+')">Apply</button>'+
+  '</div>';
+}
+function renderRetagProposal(p,pi){
+  const cur=p.kind==='album'?(p.current.artist+' — '+p.current.album):(p.current.artist+' — '+p.current.title);
+  return '<div class="section" style="margin-bottom:0.75rem;">'+
+    '<div class="lib-row-meta">Currently: <b>'+escapeHtml(cur)+'</b> · '+p.item_count+' track'+(p.item_count===1?'':'s')+'</div>'+
+    '<div class="candidate-list">'+p.candidates.map((c,ci)=>retagCandidateCard(c,ci,pi,p.current,p.kind)).join('')+'</div>'+
+  '</div>';
+}
+function applyRetagCandidate(pi,ci){
+  const p=retagProposals[pi];
+  if(!p||!jobRunner.id)return;
+  postJSON('/retag/'+jobRunner.id+'/apply',{kind:p.kind,target_id:p.target_id,candidate:ci})
+    .then(data=>{
+      if(!data.ok){alert('Could not apply: '+data.error);return;}
+      retagProposals.splice(pi,1);
+      renderResult(retagSummaryHtml(retagLastDoneEvent)+renderRetagList());
+    })
+    .catch(()=>alert('Could not reach the server.'));
 }
 
 // ── Filter (#64) ──────────────────────────────────────────────────────────────

--- a/fingerprint.py
+++ b/fingerprint.py
@@ -1,0 +1,50 @@
+"""
+Fingerprint backfill (#90) — background job that computes and stores
+AcoustID/chromaprint fingerprints for items that don't have one yet.
+
+Local-only: beetsplug.chroma.fingerprint_item() calls
+acoustid.fingerprint_file() (chromaprint/fpcalc) directly — no network call,
+no AcoustID lookup. That's deliberate: this job exists only to backfill
+item.acoustid_fingerprint for items imported before chroma was enabled
+(quiet_fallback: asis skips the matching stage entirely, see #90) — a
+prerequisite for fingerprint-based duplicate detection in
+importsession.py's _decide_duplicate, which reads this field for the
+*existing* side of a comparison but never computes it there.
+
+Needs pyacoustid installed (`pipx inject beets pyacoustid`) and the chroma
+plugin enabled — same requirement the config-builder wizard already
+recommends (beetsgui.html: `chroma:\n  auto: yes`).
+"""
+from beets import logging as beets_logging
+
+import jobs
+from importsession import get_library
+from libops import split_query
+
+log = beets_logging.getLogger('beetsgui.fingerprint')
+
+
+def _run(job):
+    from beetsplug import chroma   # raises ImportError -> reported as the
+                                    # job's 'error' event if pyacoustid isn't
+                                    # installed, same as sync.py's _plugin()
+    lib = get_library()
+    query = split_query(job.meta.get('query', ''))
+    items = [i for i in lib.items(query) if not i.acoustid_fingerprint]
+    total = len(items)
+    job.result['total'] = total
+    job.result['fingerprinted'] = 0
+    job.emit('status', message=f'{total} item(s) without a fingerprint')
+    for i, item in enumerate(items, 1):
+        if job.aborted.is_set():
+            return
+        if chroma.fingerprint_item(log, item, write=False, quiet=True) is not None:
+            job.result['fingerprinted'] += 1
+        job.emit('status', message=f'{i}/{total}: {item}')
+
+
+def start(query=''):
+    """Start a fingerprint backfill job over the scope query. Raises
+    RuntimeError if another job is running."""
+    job = jobs.Job('fingerprint', query=query)
+    return jobs.start(job, _run)

--- a/importsession.py
+++ b/importsession.py
@@ -21,6 +21,7 @@ import threading
 import uuid
 
 from beets import config, context, plugins, ui
+from beets import logging as beets_logging
 try:
     from beets.autotag.match import AlbumMatch   # beets >= 2.13
 except ImportError:
@@ -32,7 +33,22 @@ except ImportError:
 from beets.importer import Action, ImportAbortError, ImportSession
 from beets.util import displayable_path
 
+# Local-only fingerprint comparison (#90) — acoustid.compare_fingerprints()
+# never touches the network, unlike the AcoustID *lookup* the chroma
+# plugin's `auto: yes` also does. Both come from pyacoustid
+# (`pipx inject beets pyacoustid`); if it isn't installed, dedup falls back
+# to the title-overlap heuristic below unconditionally.
+try:
+    import acoustid
+    from beetsplug import chroma
+except ImportError:
+    acoustid = None
+    chroma = None
+
 import jobs
+import settings
+
+_dedup_log = beets_logging.getLogger('beetsgui.dedup')
 
 # A blocked decision gives up after this long, so a closed browser tab
 # cannot pin an importer thread forever.
@@ -160,6 +176,47 @@ def quality_rank(items):
     if not items:
         return (0, 0, 0, 0)
     return min(_track_quality(i) for i in items)
+
+
+def _incoming_fingerprints(items):
+    """Local chromaprint fingerprints for the items being imported.
+
+    Computed live, here — that's cheap and expected: the file is already
+    being read for import. `fingerprint_item` caches on the Item object
+    (in-memory), so calling this once per _decide_duplicate() call and
+    reusing the result across every duplicate candidate costs one fpcalc
+    run per item, not one per candidate.
+    """
+    if acoustid is None:
+        return []
+    return [fp for fp in
+            (chroma.fingerprint_item(_dedup_log, i, write=False, quiet=True)
+             for i in items)
+            if fp]
+
+
+def _fingerprint_match(incoming_fps, dup_items, threshold):
+    """True/False if fingerprint comparison against `dup_items` is decisive,
+    None if neither side has a fingerprint to compare (caller falls back to
+    title overlap).
+
+    The *existing* side's fingerprint is read as stored — never computed
+    live here. That's fingerprint.py's backfill job, meant to run ahead of
+    time (#90): this decision has to stay fast regardless of library size,
+    and an existing item's audio file may not even be on a currently
+    mounted volume.
+    """
+    if not incoming_fps:
+        return None
+    existing_fps = [i.acoustid_fingerprint for i in dup_items if i.acoustid_fingerprint]
+    if not existing_fps:
+        return None
+    for fp in incoming_fps:
+        for efp in existing_fps:
+            score = acoustid.compare_fingerprints((0, fp.encode()), (0, efp.encode()))
+            if score >= threshold:
+                return True
+    return False
 
 
 def _summarize(obj, is_album):
@@ -387,10 +444,36 @@ class WebImportSession(ImportSession):
             dup_items = dup.items() if task.is_album else [dup]
             dup_titles = {i.title.strip().lower() for i in dup_items if i.title}
             return not incoming_titles or not dup_titles or bool(incoming_titles & dup_titles)
-        found_duplicates = [d for d in found_duplicates if _titles_overlap(d)]
+
+        # Fingerprint identity is the actual audio, not the tag, so it
+        # overrides the title-overlap guess above whenever both sides have
+        # one to compare (#90) — this both rescues a false positive (same
+        # album name, different song, coincidentally same title too) and
+        # catches a false negative title-overlap alone would miss (same
+        # recording, retagged differently). Falls back to title overlap
+        # per-candidate when a fingerprint isn't available on either side.
+        threshold = settings.load()['dedup_fingerprint_threshold']
+        incoming_fps = _incoming_fingerprints(items)
+        match_reason = {}
+        fingerprint_excluded = False
+        def _is_duplicate(dup):
+            nonlocal fingerprint_excluded
+            dup_items = dup.items() if task.is_album else [dup]
+            fp_match = _fingerprint_match(incoming_fps, dup_items, threshold)
+            if fp_match is True:
+                match_reason[id(dup)] = 'fingerprint'
+                return True
+            if fp_match is False:
+                fingerprint_excluded = True
+                return False
+            match_reason[id(dup)] = 'title'
+            return _titles_overlap(dup)
+        found_duplicates = [d for d in found_duplicates if _is_duplicate(d)]
         if not found_duplicates:
-            self.job.emit('status', message=(
-                'Auto-keep: same album name, different track — not a duplicate'))
+            message = ('Auto-keep: title matches but audio fingerprint differs — '
+                       'not a duplicate') if fingerprint_excluded else (
+                'Auto-keep: same album name, different track — not a duplicate')
+            self.job.emit('status', message=message)
             return 'keep'
 
         new_rank = quality_rank(items)
@@ -429,7 +512,9 @@ class WebImportSession(ImportSession):
         payload = {
             'kind':      'duplicate',
             'is_album':  task.is_album,
-            'existing':  [_summarize(d, task.is_album) for d in found_duplicates],
+            'existing':  [{**_summarize(d, task.is_album),
+                          'matched_by': match_reason.get(id(d), 'title')}
+                         for d in found_duplicates],
             'new': {
                 'artist': chosen.get('artist'),
                 'name':   chosen.get('album') if task.is_album else chosen.get('title'),

--- a/retag.py
+++ b/retag.py
@@ -1,0 +1,187 @@
+"""
+Dry-run re-tag preview + apply (#90) — AcoustID/chroma-assisted
+MusicBrainz re-matching for items whose *tags* are wrong (a record label
+sitting in the artist field is the motivating case — a plain re-fetch
+against the existing, wrong tags just fails the same way it did on
+import).
+
+Runs the exact matching beets' own importer uses — autotag.tag_album()/
+tag_item(), the same AlbumMatch/TrackMatch objects the Import tab's
+candidate cards already render (importsession._candidate()/_track_row(),
+reused here unchanged) — directly against already-in-library items
+instead of files on disk. preview() only proposes and writes nothing;
+apply() is a separate, explicit, per-album/item step, gated by the same
+"one beets job at a time" rule as every other mutating endpoint
+(server.py's _busy_response(), checked before calling apply() here) since
+it touches the same process-global Library.
+
+Network-bound like mbsync/bpsync (one MusicBrainz search, and — if
+pyacoustid/chroma is installed — one AcoustID lookup, per album/item), so
+this runs as a background job with the same "can be slow on a real
+library" caveat as those.
+"""
+from beets import autotag
+from beets import logging as beets_logging
+
+import jobs
+from importsession import _candidate, get_library
+from libops import split_query
+
+try:
+    from beetsplug import chroma
+except ImportError:
+    chroma = None
+
+log = beets_logging.getLogger('beetsgui.retag')
+
+
+def _prime_acoustid(items):
+    """Populate chroma's fingerprint/AcoustID match cache for these items
+    (a network AcoustID lookup per item) so tag_album()/tag_item()'s
+    metadata-source aggregation picks up AcoustID-derived MusicBrainz
+    candidates alongside whatever plain-text search the enabled source
+    plugins (musicbrainz, discogs, ...) already do. A no-op if chroma/
+    pyacoustid isn't installed — matching then falls back to those other
+    sources alone, same as it always has.
+
+    Always looks fingerprints up fresh rather than reusing a stored
+    item.acoustid_fingerprint — matching chroma's own import-time
+    behavior. ponytail: one AcoustID call per item per preview run, even
+    on a re-scan; skip only if that turns out to be a real API-courtesy
+    problem on a large library.
+    """
+    if chroma is None:
+        return
+    for item in items:
+        chroma.acoustid_match(log, item.path)
+
+
+def _serialize(kind, target_id, cur_artist, cur_name, item_count, proposal):
+    return {
+        'kind':           kind,
+        'target_id':      target_id,
+        'current':        ({'artist': cur_artist, 'album': cur_name} if kind == 'album'
+                           else {'artist': cur_artist, 'title': cur_name}),
+        'item_count':     item_count,
+        'recommendation': proposal.recommendation.name,
+        'candidates':     [_candidate(m, i) for i, m in enumerate(proposal.candidates or [])],
+    }
+
+
+class RetagJob(jobs.Job):
+    """Adds the proposal store to the base job: _run() fills
+    self.proposals[(kind, target_id)] with the live AlbumMatch/TrackMatch
+    candidates (holding the actual beets Item objects matched against —
+    not JSON, never emitted, kept only for apply() to use directly rather
+    than re-fetching and risking a mismatch). Cleared implicitly whenever
+    another job starts and this one is swept from the registry (jobs.py) —
+    apply() reports that plainly rather than silently doing nothing.
+    """
+
+    def __init__(self, query):
+        super().__init__('retag', query=query)
+        self.proposals = {}
+        self.result['albums_scanned'] = 0
+        self.result['items_scanned'] = 0
+        self.result['proposals_found'] = 0
+
+
+def _run(job):
+    lib = get_library()
+    query = split_query(job.meta.get('query', ''))
+
+    for album in lib.albums(query):
+        if job.aborted.is_set():
+            return
+        items = album.items()
+        _prime_acoustid(items)
+        cur_artist, cur_album, proposal = autotag.tag_album(items)
+        job.result['albums_scanned'] += 1
+        if proposal.candidates:
+            job.proposals[('album', album.id)] = proposal.candidates
+            job.result['proposals_found'] += 1
+            job.emit('proposal', **_serialize(
+                'album', album.id, cur_artist, cur_album, len(items), proposal))
+        job.emit('status', message=(
+            f"{job.result['albums_scanned']} album(s) scanned, "
+            f"{job.result['proposals_found']} with a candidate"))
+
+    singletons = [i for i in lib.items(query) if not i.album_id]
+    for item in singletons:
+        if job.aborted.is_set():
+            return
+        _prime_acoustid([item])
+        proposal = autotag.tag_item(item)
+        job.result['items_scanned'] += 1
+        if proposal.candidates:
+            job.proposals[('item', item.id)] = proposal.candidates
+            job.result['proposals_found'] += 1
+            job.emit('proposal', **_serialize(
+                'item', item.id, item.artist, item.title, 1, proposal))
+        job.emit('status', message=(
+            f"{job.result['albums_scanned']} album(s), "
+            f"{job.result['items_scanned']} singleton(s) scanned, "
+            f"{job.result['proposals_found']} with a candidate"))
+
+
+def start(query=''):
+    """Start a retag preview job over the scope query. Raises RuntimeError
+    if another job is running."""
+    job = RetagJob(query)
+    return jobs.start(job, _run)
+
+
+def apply(job_id, kind, target_id, candidate_index):
+    """Apply one previewed candidate: writes tags to the file and updates
+    the library. This is the only place a retag preview actually changes
+    anything — preview() itself never does. Returns an error string, or
+    None on success.
+
+    Applies through the *same* Item objects the preview matched against
+    (held on the job, not re-fetched) — apply_metadata() only knows how to
+    update the objects it was built from. A light existence check catches
+    the case where an item/album was removed since the preview ran.
+    """
+    job = jobs.get(job_id)
+    if job is None or not hasattr(job, 'proposals'):
+        return 'unknown retag job — its proposals are gone; preview again'
+    candidates = job.proposals.get((kind, target_id))
+    if candidates is None:
+        return 'no proposal for that album/item — preview again'
+    if not 0 <= candidate_index < len(candidates):
+        return f'candidate must be 0..{len(candidates) - 1}'
+    match = candidates[candidate_index]
+
+    lib = get_library()
+    items = match.items if kind == 'album' else [match.item]
+    if any(lib.get_item(i.id) is None for i in items):
+        return 'one or more items no longer exist — preview again'
+
+    match.apply_metadata()
+    # Free synergy with fingerprint.py's backfill (#90): the AcoustID
+    # lookup during preview already computed a local fingerprint for
+    # these items (chroma._fingerprints, keyed by path) even when no
+    # network match came back for the *chosen* candidate — persist it now
+    # that the item is being written anyway, instead of leaving it for a
+    # separate backfill pass to redo the same fpcalc work.
+    if chroma is not None:
+        for item in items:
+            fp = chroma._fingerprints.get(item.path)
+            if fp:
+                item.acoustid_fingerprint = fp
+
+    if kind == 'album':
+        album = lib.get_album(target_id)
+        if album is None:
+            return 'album no longer exists — preview again'
+        match.apply_album_metadata(album)
+        with lib.transaction():
+            for item in items:
+                item.try_sync(True, False)
+            album.store()
+    else:
+        with lib.transaction():
+            items[0].try_sync(True, False)
+
+    del job.proposals[(kind, target_id)]
+    return None

--- a/server.py
+++ b/server.py
@@ -29,9 +29,12 @@ except ImportError:
 try:
     import artwork
     import duplicates
+    import fingerprint
     import importsession
     import jobs
     import libops
+    import retag
+    import settings
     import sync
     import traktor
     import transcode
@@ -1231,6 +1234,106 @@ def sync_start():
     except RuntimeError as e:
         return jsonify({'ok': False, 'error': str(e)}), 409
     return jsonify({'ok': True, **job.summary()})
+
+
+@app.route('/fingerprint/start', methods=['POST'])
+def fingerprint_start():
+    """Backfill AcoustID/chromaprint fingerprints for items that don't have
+    one yet (#90) — local-only, no network call. Prerequisite for
+    fingerprint-based duplicate detection in importsession.py. Body:
+    {"scope": {...}}. Progress streams on /jobs/<id>/events."""
+    data = request.get_json(silent=True) or {}
+    try:
+        job = fingerprint.start(query=libops.scope_query(data))
+    except RuntimeError as e:
+        return jsonify({'ok': False, 'error': str(e)}), 409
+    return jsonify({'ok': True, **job.summary()})
+
+
+def _chroma_available():
+    try:
+        import acoustid   # noqa: F401 — presence check only
+        return True
+    except ImportError:
+        return False
+
+
+@app.route('/dedup/settings')
+def dedup_settings():
+    """Fingerprint-based duplicate-detection settings (#90) — the threshold
+    plus how much of the library actually has a fingerprint to compare
+    against, so the number in Preferences means something rather than
+    being tuned blind."""
+    con = _library_con()
+    total = fingerprinted = 0
+    if con is not None:
+        total = con.execute('SELECT COUNT(*) FROM items').fetchone()[0]
+        fingerprinted = con.execute(
+            "SELECT COUNT(*) FROM items WHERE acoustid_fingerprint != ''"
+        ).fetchone()[0]
+        con.close()
+    return jsonify({'ok': True, **settings.load(),
+                    'total': total, 'fingerprinted': fingerprinted,
+                    'chroma_available': _chroma_available()})
+
+
+@app.route('/dedup/settings', methods=['POST'])
+def dedup_settings_save():
+    """Body: {"dedup_fingerprint_threshold": 0.95}. The score two
+    fingerprints (acoustid.compare_fingerprints(), 0..1) must reach to
+    count as the same recording in importsession._decide_duplicate."""
+    data = request.get_json(silent=True) or {}
+    threshold = data.get('dedup_fingerprint_threshold')
+    try:
+        threshold = float(threshold)
+    except (TypeError, ValueError):
+        return jsonify({'ok': False,
+                        'error': 'dedup_fingerprint_threshold must be a number'}), 400
+    if not 0 < threshold <= 1:
+        return jsonify({'ok': False,
+                        'error': 'dedup_fingerprint_threshold must be between 0 and 1'}), 400
+    return jsonify({'ok': True, **settings.save({'dedup_fingerprint_threshold': threshold})})
+
+
+@app.route('/retag/start', methods=['POST'])
+def retag_start():
+    """Dry-run AcoustID/MusicBrainz re-tag preview (#90) — proposes
+    candidates for albums/singletons whose *tags* may be wrong, writes
+    nothing. Body: {"scope": {...}}. Progress streams on
+    /jobs/<id>/events, one 'proposal' event per album/item that got a
+    candidate; review and apply each individually via /retag/<id>/apply
+    once the job is done (applying is gated by _busy_response() below, so
+    it waits for the scan itself to finish first)."""
+    data = request.get_json(silent=True) or {}
+    try:
+        job = retag.start(query=libops.scope_query(data))
+    except RuntimeError as e:
+        return jsonify({'ok': False, 'error': str(e)}), 409
+    return jsonify({'ok': True, **job.summary()})
+
+
+@app.route('/retag/<job_id>/apply', methods=['POST'])
+def retag_apply(job_id):
+    """Apply one previewed candidate. Body: {"kind": "album"|"item",
+    "target_id": 123, "candidate": 0}. Writes tags to the file and
+    updates the library — the only place a retag preview actually
+    changes anything."""
+    if busy := _busy_response():
+        return busy
+    data = request.get_json(silent=True) or {}
+    kind = data.get('kind')
+    if kind not in ('album', 'item'):
+        return jsonify({'ok': False, 'error': 'kind must be "album" or "item"'}), 400
+    try:
+        target_id = int(data.get('target_id'))
+        candidate = int(data.get('candidate', 0))
+    except (TypeError, ValueError):
+        return jsonify({'ok': False,
+                        'error': 'target_id and candidate must be integers'}), 400
+    error = retag.apply(job_id, kind, target_id, candidate)
+    if error:
+        return jsonify({'ok': False, 'error': error}), 409
+    return jsonify({'ok': True})
 
 
 @app.route('/traktor/scan/start', methods=['POST'])

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,49 @@
+"""
+Small persisted settings for beetsGUI itself (#90) — distinct from beets'
+own config.yaml, which this app only ever reads (Preferences generates a
+config.yaml block for the user to paste in by hand; nothing here writes to
+that file). Stored as JSON next to library.db, same "app-owned state file"
+pattern as traktor.py's recovery list.
+
+One key so far: the AcoustID/chromaprint similarity score
+(acoustid.compare_fingerprints(), 0..1) importsession._decide_duplicate
+needs to call two fingerprints "the same recording". Read fresh (no
+caching) on every duplicate decision and every /dedup/settings request —
+it's a few bytes of JSON, and a stale in-memory copy after a Preferences
+change is a worse trade than the file read.
+"""
+import json
+import os
+
+from beets import config
+
+DEFAULTS = {
+    'dedup_fingerprint_threshold': 0.95,
+}
+
+
+def _path():
+    return os.path.join(os.path.dirname(config['library'].as_filename()),
+                        'beetsgui_settings.json')
+
+
+def load():
+    try:
+        with open(_path(), 'r', encoding='utf-8') as f:
+            saved = json.load(f)
+    except (OSError, ValueError):
+        saved = {}
+    return {**DEFAULTS, **{k: v for k, v in saved.items() if k in DEFAULTS}}
+
+
+def save(values):
+    """Merge `values` into the stored settings (keys outside DEFAULTS are
+    ignored) and write atomically. Returns the settings afterward."""
+    current = load()
+    current.update({k: v for k, v in values.items() if k in DEFAULTS})
+    path = _path()
+    tmp = path + '.tmp'
+    with open(tmp, 'w', encoding='utf-8') as f:
+        json.dump(current, f)
+    os.replace(tmp, path)
+    return current

--- a/test_dedup_fingerprint.py
+++ b/test_dedup_fingerprint.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Unit tests for #90's fingerprint-based duplicate detection.
+
+Three things get exercised without a real beets library, real audio, or a
+running server (same style as test_scope.py/test_libops.py):
+
+1. importsession._incoming_fingerprints()/_fingerprint_match() — the actual
+   new decision logic — with acoustid/chroma faked out. In particular: a
+   fingerprint match must override a title-overlap guess in both
+   directions (confirm a same-audio/different-tag duplicate a title check
+   would miss; rescue a same-title/different-audio false positive), and
+   the *existing* side's fingerprint must only ever be read, never
+   computed live (that's fingerprint.py's backfill job, run ahead of time).
+2. settings.py's load/save round-trip and default/corrupt-file fallback.
+3. server.py's /dedup/settings validation, with settings.py's own
+   load/save monkeypatched so nothing here ever resolves a real beets
+   config.yaml/library.db (same discipline test_scope.py uses for
+   /library/remove etc: an in-process Flask test must never reach the
+   real config).
+
+Run: ~/.local/pipx/venvs/beets/bin/python test_dedup_fingerprint.py
+"""
+import pathlib
+import tempfile
+
+import importsession
+import server
+import settings
+
+
+class FakeItem:
+    def __init__(self, id, title='', fp=None):
+        self.id = id
+        self.title = title
+        self.acoustid_fingerprint = fp
+
+    def __str__(self):
+        return f'item {self.id}'
+
+
+class FakeAcoustid:
+    def __init__(self, score):
+        self.score = score
+
+    def compare_fingerprints(self, a, b):
+        return self.score
+
+
+class FakeChroma:
+    def __init__(self, fps_by_id):
+        self.fps_by_id = fps_by_id
+
+    def fingerprint_item(self, log, item, write=False, quiet=False):
+        return self.fps_by_id.get(item.id)
+
+
+def test_fingerprint_match_confirms_even_without_title_overlap():
+    """Same audio, different tags — a real duplicate a title-only check
+    would miss entirely (#90)."""
+    importsession.acoustid = FakeAcoustid(score=0.99)
+    importsession.chroma = FakeChroma({1: 'fp-a'})
+    incoming = importsession._incoming_fingerprints([FakeItem(1, title='Track One')])
+    dup_items = [FakeItem(2, title='Completely Different Name', fp='fp-a')]
+    assert importsession._fingerprint_match(incoming, dup_items, 0.95) is True
+
+
+def test_fingerprint_mismatch_overrides_title_overlap():
+    """Same title, different audio — the false positive #90 exists to
+    rescue (two different DJ-pool tracks sharing a generic title)."""
+    importsession.acoustid = FakeAcoustid(score=0.10)
+    importsession.chroma = FakeChroma({1: 'fp-a'})
+    incoming = importsession._incoming_fingerprints([FakeItem(1, title='Original Mix')])
+    dup_items = [FakeItem(2, title='Original Mix', fp='fp-b')]
+    assert importsession._fingerprint_match(incoming, dup_items, 0.95) is False
+
+
+def test_falls_back_to_none_without_fingerprints():
+    """Chroma/pyacoustid unavailable — caller falls back to title overlap
+    instead of getting a decisive answer from here."""
+    importsession.acoustid = None
+    importsession.chroma = None
+    incoming = importsession._incoming_fingerprints([FakeItem(1)])
+    assert incoming == []
+    assert importsession._fingerprint_match(incoming, [FakeItem(2, fp='fp-b')], 0.95) is None
+
+
+def test_existing_side_fingerprint_never_computed_live():
+    """No acoustid_fingerprint stored on the existing item -> unavailable,
+    even though the incoming side fingerprinted fine. Confirms this never
+    tries to compute one for the existing item itself (fingerprint.py's
+    backfill job is the only thing that does that, ahead of time)."""
+    importsession.acoustid = FakeAcoustid(score=0.99)
+    importsession.chroma = FakeChroma({1: 'fp-a'})
+    incoming = importsession._incoming_fingerprints([FakeItem(1)])
+    assert importsession._fingerprint_match(incoming, [FakeItem(2, fp=None)], 0.95) is None
+
+
+def test_threshold_boundary():
+    importsession.acoustid = FakeAcoustid(score=0.95)
+    importsession.chroma = FakeChroma({1: 'fp-a'})
+    incoming = importsession._incoming_fingerprints([FakeItem(1)])
+    assert importsession._fingerprint_match(incoming, [FakeItem(2, fp='fp-b')], 0.95) is True
+    assert importsession._fingerprint_match(incoming, [FakeItem(2, fp='fp-b')], 0.96) is False
+
+
+def test_settings_round_trip(tmp_path):
+    settings._path = lambda: str(tmp_path / 'beetsgui_settings.json')
+    assert settings.load() == settings.DEFAULTS
+    saved = settings.save({'dedup_fingerprint_threshold': 0.8})
+    assert saved['dedup_fingerprint_threshold'] == 0.8
+    assert settings.load()['dedup_fingerprint_threshold'] == 0.8
+    # Unknown keys are dropped, not persisted.
+    settings.save({'not_a_real_setting': 'x'})
+    assert 'not_a_real_setting' not in settings.load()
+
+
+def test_settings_survives_a_missing_or_corrupt_file(tmp_path):
+    settings._path = lambda: str(tmp_path / 'missing.json')
+    assert settings.load() == settings.DEFAULTS
+    corrupt = tmp_path / 'corrupt.json'
+    corrupt.write_text('not json')
+    settings._path = lambda: str(corrupt)
+    assert settings.load() == settings.DEFAULTS
+
+
+def _client():
+    server.app.testing = True
+    # _reject_foreign_host() checks Host against the loopback origin, so the
+    # test client has to speak as that origin or every request is a 403.
+    server.app.config['SERVER_NAME'] = f'localhost:{server.PORT}'
+    return server.app.test_client()
+
+
+def test_dedup_settings_save_validation():
+    """Bad thresholds are a 400 before ever touching settings.py's file
+    I/O — proven by making settings.save() explode if reached."""
+    client = _client()
+    settings.save = lambda values: (_ for _ in ()).throw(
+        AssertionError('should not reach settings.save for a bad value'))
+    for bad in (None, 'x', 0, -0.1, 1.1, [0.9]):
+        r = client.post('/dedup/settings', json={'dedup_fingerprint_threshold': bad})
+        assert r.status_code == 400, (bad, r.status_code, r.get_json())
+        assert r.get_json()['ok'] is False
+
+    seen = []
+    settings.save = lambda values: seen.append(values) or {**settings.DEFAULTS, **values}
+    r = client.post('/dedup/settings', json={'dedup_fingerprint_threshold': 0.9})
+    assert r.status_code == 200, r.get_json()
+    assert seen == [{'dedup_fingerprint_threshold': 0.9}], seen
+
+
+def main():
+    test_fingerprint_match_confirms_even_without_title_overlap()
+    test_fingerprint_mismatch_overrides_title_overlap()
+    test_falls_back_to_none_without_fingerprints()
+    test_existing_side_fingerprint_never_computed_live()
+    test_threshold_boundary()
+
+    with tempfile.TemporaryDirectory() as d:
+        test_settings_round_trip(pathlib.Path(d))
+    with tempfile.TemporaryDirectory() as d:
+        test_settings_survives_a_missing_or_corrupt_file(pathlib.Path(d))
+
+    test_dedup_settings_save_validation()
+    print('dedup fingerprint: ok')
+
+
+if __name__ == '__main__':
+    main()

--- a/test_fingerprint.py
+++ b/test_fingerprint.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Unit test for #90's fingerprint backfill job (fingerprint.py).
+
+fingerprint_item() itself is beets' own, already-tested code (chroma.py) —
+what's actually new here is: filtering to items that don't have a
+fingerprint yet (so a re-run doesn't recompute 1600 fingerprints it already
+has), turning the results into job.result counts, and stopping on abort.
+This fakes get_library()/chroma.fingerprint_item() so the check runs
+without fpcalc, a real audio file, or a beets library on disk.
+
+Run: ~/.local/pipx/venvs/beets/bin/python test_fingerprint.py
+"""
+from beetsplug import chroma
+
+import fingerprint
+import jobs
+
+
+class FakeItem:
+    def __init__(self, id, fp=None):
+        self.id = id
+        self.acoustid_fingerprint = fp
+
+    def __str__(self):
+        return f'item {self.id}'
+
+
+class FakeLib:
+    def __init__(self, items):
+        self._items = items
+
+    def items(self, query):
+        return list(self._items)
+
+
+def test_skips_items_already_fingerprinted():
+    """Items with a fingerprint already stored are never touched — that's
+    what makes a re-run of this job cheap on a mostly-backfilled library."""
+    items = [FakeItem(1, fp=None), FakeItem(2, fp='already-there'), FakeItem(3, fp=None)]
+    fingerprint.get_library = lambda: FakeLib(items)
+
+    seen = []
+    def fake_fingerprint_item(log, item, write=False, quiet=False):
+        seen.append(item.id)
+        return 'computed'
+    chroma.fingerprint_item = fake_fingerprint_item
+
+    job = jobs.Job('fingerprint', query='')
+    fingerprint._run(job)
+
+    assert seen == [1, 3], seen
+    assert job.result['total'] == 2, job.result
+    assert job.result['fingerprinted'] == 2, job.result
+
+
+def test_abort_stops_the_loop():
+    """job.aborted mid-loop stops before the next item, same contract as
+    every other job in this codebase (sync.py, transcode.py)."""
+    items = [FakeItem(1), FakeItem(2), FakeItem(3)]
+    fingerprint.get_library = lambda: FakeLib(items)
+
+    job = jobs.Job('fingerprint', query='')
+    calls = []
+    def fake_fingerprint_item(log, item, write=False, quiet=False):
+        calls.append(item.id)
+        job.aborted.set()   # abort right after the first item is processed
+        return 'computed'
+    chroma.fingerprint_item = fake_fingerprint_item
+
+    fingerprint._run(job)
+    assert calls == [1], calls
+    assert job.result['fingerprinted'] == 1, job.result
+
+
+def test_a_failed_fingerprint_is_not_counted():
+    """fingerprint_item() returns None when generation fails (e.g. no
+    duration, or fpcalc errors) — that must not count as backfilled."""
+    items = [FakeItem(1)]
+    fingerprint.get_library = lambda: FakeLib(items)
+    chroma.fingerprint_item = lambda log, item, write=False, quiet=False: None
+
+    job = jobs.Job('fingerprint', query='')
+    fingerprint._run(job)
+    assert job.result['fingerprinted'] == 0, job.result
+
+
+def main():
+    test_skips_items_already_fingerprinted()
+    test_abort_stops_the_loop()
+    test_a_failed_fingerprint_is_not_counted()
+    print('fingerprint backfill: ok')
+
+
+if __name__ == '__main__':
+    main()

--- a/test_retag.py
+++ b/test_retag.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Tests for #90's retag dry-run preview + apply (retag.py).
+
+_run()/_prime_acoustid() (the actual MusicBrainz/AcoustID network calls)
+aren't covered here — same precedent as sync.py, which has no test file
+either, for the same reason: it's thin glue over real network-dependent
+beets plugin calls, unsuitable for a deterministic offline test. That path
+was smoke-tested by hand against real MusicBrainz during development: a
+synthetic file tagged artist="Sofa Beets" (a fabricated wrong tag, the
+motivating #90 scenario) matched real MusicBrainz candidates, one of which
+was applied end-to-end and verified with ffprobe to have actually
+rewritten the file.
+
+What's tested here, offline and deterministic:
+1. _serialize() — the exact JSON shape beetsgui.html's candidateCard()
+   renders, built from real (but network-free, hand-constructed)
+   AlbumMatch/TrackMatch objects — the same classes tag_album()/
+   tag_item() return.
+2. apply()'s actual write path — a real beets Item/Library/audio file,
+   with a fake AlbumInfo/TrackInfo standing in for what a real
+   MusicBrainz match would carry. Proves apply_metadata() + try_sync()
+   actually rewrites the file and the database, including mb_trackid,
+   and that a successfully-applied proposal can't be double-applied.
+3. apply()'s error paths: unknown job, no matching proposal, an
+   out-of-range candidate index, and an item deleted since preview.
+
+Needs ffmpeg (a real, tiny test audio file), same as
+test_importsession.py/test_fingerprint.py.
+
+Run: ~/.local/pipx/venvs/beets/bin/python test_retag.py
+"""
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from beets import library
+from beets.autotag.distance import Distance
+from beets.autotag.hooks import AlbumInfo, TrackInfo
+from beets.autotag.match import AlbumMatch, Proposal, Recommendation, TrackMatch
+from mediafile import MediaFile
+
+import jobs
+import retag
+
+
+class FakeItem:
+    """Stand-in for a beets Item — only the attributes _candidate()/
+    _track_row() actually read, for the offline _serialize() tests."""
+    def __init__(self, title, artist, length=3.0):
+        self.title = title
+        self.artist = artist
+        self.length = length
+
+
+def _fake_album_proposal(item):
+    tracks = [TrackInfo(title='Fiaker (Driving Home to Hasenearl)', artist='Sofa Surfers',
+                        track_id='track-1', index=1)]
+    info = AlbumInfo(tracks=tracks, album='Sofa Rockers', artist='Sofa Surfers',
+                     album_id='album-1', artist_id='artist-1', data_source='Test',
+                     data_url='https://example.com/album-1', label='Klein Records',
+                     country='AT', media='CD', albumtype='ep', year=1997)
+    match = AlbumMatch(distance=Distance(), info=info, mapping={item: tracks[0]})
+    return Proposal(candidates=[match], recommendation=Recommendation.low)
+
+
+def test_serialize_album():
+    """The exact shape candidateCard() (beetsgui.html) reads."""
+    item = FakeItem(title='Untitled Track', artist='Sofa Beets')
+    proposal = _fake_album_proposal(item)
+    payload = retag._serialize('album', 42, 'Sofa Beets', 'Sofa Beets', 1, proposal)
+
+    assert payload['kind'] == 'album'
+    assert payload['target_id'] == 42
+    assert payload['current'] == {'artist': 'Sofa Beets', 'album': 'Sofa Beets'}
+    assert payload['item_count'] == 1
+    assert payload['recommendation'] == 'low'
+    c = payload['candidates'][0]
+    assert c['artist'] == 'Sofa Surfers', c
+    assert c['title'] == 'Sofa Rockers', c
+    assert c['label'] == 'Klein Records', c
+    assert c['data_source'] == 'Test', c
+    track = c['tracks'][0]
+    assert track['current'] == 'Untitled Track' and track['new'] == 'Fiaker (Driving Home to Hasenearl)', track
+    assert track['current_artist'] == 'Sofa Beets' and track['new_artist'] == 'Sofa Surfers', track
+
+
+def test_serialize_item():
+    """Singleton (TrackMatch) shape — same field names as the album case,
+    per candidateCard()'s expectations."""
+    info = TrackInfo(title='Fiaker (Driving Home to Hasenearl)', artist='Sofa Surfers',
+                     track_id='track-1', data_source='Test', data_url='https://example.com/t-1')
+    item = FakeItem(title='Untitled', artist='Magician On Duty')
+    match = TrackMatch(distance=Distance(), info=info, item=item)
+    proposal = Proposal(candidates=[match], recommendation=Recommendation.medium)
+
+    payload = retag._serialize('item', 7, 'Magician On Duty', 'Untitled', 1, proposal)
+    assert payload['kind'] == 'item'
+    assert payload['current'] == {'artist': 'Magician On Duty', 'title': 'Untitled'}
+    assert payload['recommendation'] == 'medium'
+    assert payload['candidates'][0]['title'] == 'Fiaker (Driving Home to Hasenearl)'
+
+
+def _make_library(tmp_dir):
+    music = tmp_dir / 'music'
+    music.mkdir()
+    src = music / 'track.mp3'
+    subprocess.run([
+        'ffmpeg', '-f', 'lavfi', '-i', 'sine=frequency=440:duration=1', '-ar', '44100',
+        '-metadata', 'artist=Sofa Beets', '-metadata', 'title=Untitled Track',
+        '-metadata', 'album=Sofa Beets', str(src), '-y', '-loglevel', 'error',
+    ], check=True)
+    lib = library.Library(str(tmp_dir / 'library.db'), str(music))
+    item = library.Item.from_path(str(src))
+    item.add(lib)
+    album = lib.add_album([item])
+    return lib, album, item
+
+
+def test_apply_album_writes_file_and_database():
+    if shutil.which('ffmpeg') is None:
+        print('ffmpeg not found — skipping test_apply_album_writes_file_and_database')
+        return
+    with tempfile.TemporaryDirectory() as d:
+        lib, album, item = _make_library(Path(d))
+        retag.get_library = lambda: lib
+        proposal = _fake_album_proposal(item)
+        job = retag.RetagJob('')
+        job.proposals[('album', album.id)] = proposal.candidates
+        jobs.get = lambda job_id: job if job_id == job.id else None
+
+        error = retag.apply(job.id, 'album', album.id, 0)
+        assert error is None, error
+
+        mf = MediaFile(item.path)
+        assert mf.artist == 'Sofa Surfers', mf.artist
+        assert mf.title == 'Fiaker (Driving Home to Hasenearl)', mf.title
+        assert mf.album == 'Sofa Rockers', mf.album
+
+        fresh_item = lib.get_item(item.id)
+        assert fresh_item.artist == 'Sofa Surfers', fresh_item.artist
+        assert fresh_item.mb_trackid == 'track-1', fresh_item.mb_trackid
+        fresh_album = lib.get_album(album.id)
+        assert fresh_album.albumartist == 'Sofa Surfers', fresh_album.albumartist
+
+        # Consumed — can't be double-applied.
+        assert ('album', album.id) not in job.proposals
+        assert retag.apply(job.id, 'album', album.id, 0) == \
+            'no proposal for that album/item — preview again'
+
+
+def test_apply_unknown_job():
+    jobs.get = lambda job_id: None
+    error = retag.apply('does-not-exist', 'album', 1, 0)
+    assert error and 'unknown retag job' in error, error
+
+
+def test_apply_no_proposal_for_target():
+    job = retag.RetagJob('')
+    jobs.get = lambda job_id: job
+    error = retag.apply(job.id, 'album', 999, 0)
+    assert error and 'no proposal' in error, error
+
+
+def test_apply_candidate_index_out_of_range():
+    job = retag.RetagJob('')
+    job.proposals[('album', 1)] = ['placeholder-match']
+    jobs.get = lambda job_id: job
+    error = retag.apply(job.id, 'album', 1, 5)
+    assert error and 'candidate must be' in error, error
+
+
+def test_apply_stale_item_is_rejected():
+    """An item removed from the library since preview — must not try to
+    write through a Match holding a since-deleted Item."""
+    class FakeMatch:
+        items = [FakeItem('x', 'y')]
+        items[0].id = 1
+    class FakeLib:
+        def get_item(self, item_id):
+            return None   # deleted since preview
+    job = retag.RetagJob('')
+    job.proposals[('album', 1)] = [FakeMatch()]
+    jobs.get = lambda job_id: job
+    retag.get_library = lambda: FakeLib()
+
+    error = retag.apply(job.id, 'album', 1, 0)
+    assert error and 'no longer exist' in error, error
+
+
+def main():
+    test_serialize_album()
+    test_serialize_item()
+    test_apply_album_writes_file_and_database()
+    test_apply_unknown_job()
+    test_apply_no_proposal_for_target()
+    test_apply_candidate_index_out_of_range()
+    test_apply_stale_item_is_rejected()
+    print('retag: ok')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- `fingerprint.py` — local-only fingerprint backfill job (no network), prerequisite for the dedup half.
- `retag.py` — dry-run AcoustID/MusicBrainz re-tag preview (preview writes nothing; apply is a separate per-album/item step, gated behind the usual single-job lock).
- `importsession.py`'s `_decide_duplicate` now prefers local fingerprint comparison over the title-overlap heuristic when a fingerprint is available on both sides; threshold is configurable in Preferences (`settings.py`, `/dedup/settings`), with live coverage stats.

Closes #90

## Test plan
- [x] `test_fingerprint.py`, `test_dedup_fingerprint.py`, `test_retag.py` — new, all green
- [x] Full existing suite (`test_libops`, `test_config_path`, `test_filter`, `test_queue`, `test_scope`, `test_pick`, `test_jobs`, `test_playback`, `test_importsession`, `test_smoke`) — all green, no regressions
- [x] Manually verified against real MusicBrainz/AcoustID (network) and a real audio file: retag preview found real candidates, apply rewrote the actual file tags (confirmed with `ffprobe`) and the database
- [x] Manually drove the Preferences UI (dedup threshold + coverage) against a live throwaway server

🤖 Generated with [Claude Code](https://claude.com/claude-code)