### PR TITLE
Add press feedback, gate hover for touch, respect reduced-motion

### DIFF
--- a/beetsgui.html
+++ b/beetsgui.html
@@ -39,6 +39,9 @@
     --font-ui:'Jost',-apple-system,BlinkMacSystemFont,sans-serif;
     --font-mono:'Drafting Mono','SF Mono','Menlo',monospace;
     --focus:0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
+    /* #112: every transition used the browser default curve. Strong
+       ease-out for entrances/press-feedback — durations stay as they were. */
+    --ease-out:cubic-bezier(0.23,1,0.32,1);
   }
   /* #107: single global keyboard-focus indicator — :focus-visible so mouse
      clicks stay quiet, only keyboard nav shows the ring. */
@@ -77,23 +80,26 @@
   .app { display:flex; flex-direction:column; height:100vh; max-width:860px; margin:0 auto; }
   .app-header { display:flex; align-items:baseline; gap:0.75rem; padding:1rem 1.25rem 0; border-bottom:1px solid var(--border); flex-shrink:0; }
   .job-queue-badge { align-self:center; margin-left:auto; font-size:11px; color:var(--text3); border:1px solid var(--border); border-radius:999px; padding:0.15rem 0.6rem; }
-  .prefs-btn { align-self:center; background:none; border:none; color:var(--text3); cursor:pointer; font-size:15px; margin-left:auto; padding:0.2rem 0.3rem; transition:color 0.1s; }
+  .prefs-btn { align-self:center; background:none; border:none; color:var(--text3); cursor:pointer; font-size:15px; margin-left:auto; padding:0.2rem 0.3rem; transition:color 0.1s,transform 160ms var(--ease-out); }
+  .prefs-btn:active { transform:scale(0.97); }
   .job-queue-panel { padding:0.4rem 1.25rem; border-top:1px solid var(--border); font-size:11px; color:var(--text3); flex-shrink:0; max-height:45vh; overflow-y:auto; }
   .job-queue-row { display:flex; align-items:center; gap:0.4rem; padding:0.15rem 0; }
   .job-queue-row .kind { flex:1; }
   .job-queue-row button { background:none; border:1px solid var(--border); border-radius:4px; color:var(--text3); cursor:pointer; font-size:10px; line-height:1.4; padding:0 0.35rem; }
   .job-queue-row button:disabled { cursor:default; opacity:0.3; }
-  .job-queue-row button:hover:not(:disabled) { color:var(--text2); }
+  @media (hover:hover) and (pointer:fine) { .job-queue-row button:hover:not(:disabled) { color:var(--text2); } }
   #job-panel-result-wrap { position:relative; padding-right:1.6rem; }
-  .job-panel-dismiss { position:absolute; top:0; right:0; background:none; border:none; color:var(--text3); cursor:pointer; font-size:14px; line-height:1; padding:0.2rem 0.3rem; }
-  .job-panel-dismiss:hover { color:var(--text); }
-  .prefs-btn:hover { color:var(--text2); }
+  .job-panel-dismiss { position:absolute; top:0; right:0; background:none; border:none; color:var(--text3); cursor:pointer; font-size:14px; line-height:1; padding:0.2rem 0.3rem; transition:transform 160ms var(--ease-out); }
+  .job-panel-dismiss:active { transform:scale(0.97); }
+  @media (hover:hover) and (pointer:fine) { .job-panel-dismiss:hover { color:var(--text); } }
+  @media (hover:hover) and (pointer:fine) { .prefs-btn:hover { color:var(--text2); } }
   #prefs-dialog { background:var(--bg); border:1px solid var(--border); border-radius:var(--radius-lg); color:var(--text); margin:auto; max-height:85vh; padding:0; width:min(620px, 92vw); }
   #prefs-dialog::backdrop { background:rgba(0,0,0,0.55); }
   .prefs-header { align-items:center; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; padding:0.85rem 1.25rem; }
   .prefs-title { color:var(--accent); font-size:13px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; }
-  .prefs-close { background:none; border:none; color:var(--text3); cursor:pointer; font-size:16px; padding:0.2rem 0.4rem; }
-  .prefs-close:hover { color:var(--text); }
+  .prefs-close { background:none; border:none; color:var(--text3); cursor:pointer; font-size:16px; padding:0.2rem 0.4rem; transition:transform 160ms var(--ease-out); }
+  .prefs-close:active { transform:scale(0.97); }
+  @media (hover:hover) and (pointer:fine) { .prefs-close:hover { color:var(--text); } }
   .prefs-body { max-height:calc(85vh - 54px); overflow-y:auto; padding:1.25rem; }
   /* .app-title is a stack of two same-position glyph layers: .shadow (behind,
      DIST driven by time of day) and .face (front, DIST=0, flat). See
@@ -104,8 +110,9 @@
   .app-sub { font-size:11px; font-weight:300; color:var(--text3); letter-spacing:0.04em; }
   .tabs { display:flex; padding:0 1.25rem; border-bottom:1px solid var(--border); flex-shrink:0; overflow-x:auto; scrollbar-width:none; }
   .tabs::-webkit-scrollbar { display:none; }
-  .tab-btn { background:none; border:none; border-bottom:2px solid transparent; color:var(--text3); cursor:pointer; font-family:inherit; font-weight:500; font-size:11px; letter-spacing:0.08em; text-transform:uppercase; padding:0.6rem 0.9rem; white-space:nowrap; transition:color 0.1s,border-color 0.1s; margin-bottom:-1px; }
-  .tab-btn:hover { color:var(--text2); }
+  .tab-btn { background:none; border:none; border-bottom:2px solid transparent; color:var(--text3); cursor:pointer; font-family:inherit; font-weight:500; font-size:11px; letter-spacing:0.08em; text-transform:uppercase; padding:0.6rem 0.9rem; white-space:nowrap; transition:color 0.1s,border-color 0.1s,transform 160ms var(--ease-out); margin-bottom:-1px; }
+  .tab-btn:active { transform:scale(0.97); }
+  @media (hover:hover) and (pointer:fine) { .tab-btn:hover { color:var(--text2); } }
   .tab-btn.active { color:var(--accent); border-bottom-color:var(--accent); }
   .content { flex:1; overflow-y:auto; padding:1.25rem; padding-bottom:0; }
   .tab-panel { display:none; }
@@ -142,15 +149,22 @@
   .drop-target.drag-over { background:var(--bg3); }
   .drop-target.drag-over::after {
     content:''; position:absolute; inset:-0.5rem; border:1.5px dashed var(--accent2);
-    border-radius:var(--radius-lg); pointer-events:none; animation:dropPulse 1s ease-in-out infinite;
+    border-radius:var(--radius-lg); pointer-events:none; opacity:0.8;
+  }
+  /* #114: pulse is decorative — the dashed border above already says "drop
+     here" without looping, so reduced-motion keeps that and just drops the
+     animation rather than losing the cue entirely. */
+  @media (prefers-reduced-motion: no-preference) {
+    .drop-target.drag-over::after { animation:dropPulse 1s ease-in-out infinite; opacity:1; }
   }
   @keyframes dropPulse { 0%,100% { opacity:0.45; } 50% { opacity:1; } }
-  .btn { background:var(--bg3); border:1px solid var(--border2); border-radius:var(--radius); color:var(--text); cursor:pointer; font-family:inherit; font-weight:500; font-size:11px; letter-spacing:0.06em; padding:0.4rem 0.75rem; text-transform:uppercase; transition:background 0.1s,border-color 0.1s; white-space:nowrap; }
-  .btn:hover { background:var(--bg4); border-color:var(--accent2); }
+  .btn { background:var(--bg3); border:1px solid var(--border2); border-radius:var(--radius); color:var(--text); cursor:pointer; font-family:inherit; font-weight:500; font-size:11px; letter-spacing:0.06em; padding:0.4rem 0.75rem; text-transform:uppercase; transition:background 0.1s,border-color 0.1s,transform 160ms var(--ease-out); white-space:nowrap; }
+  .btn:active { transform:scale(0.97); }
+  @media (hover:hover) and (pointer:fine) { .btn:hover { background:var(--bg4); border-color:var(--accent2); } }
   .btn-primary { background:var(--accent-deep); border-color:var(--accent); color:var(--on-accent); }
-  .btn-primary:hover { background:var(--accent); color:var(--bg); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { background:var(--accent); color:var(--bg); } }
   .btn-danger { background:var(--red-bg); border-color:var(--red); color:var(--red); }
-  .btn-danger:hover { background:var(--red); color:#fff; }
+  @media (hover:hover) and (pointer:fine) { .btn-danger:hover { background:var(--red); color:#fff; } }
   .btn-warn { background:var(--yellow-bg); border-color:var(--yellow); color:var(--yellow); }
   .btn-row { display:flex; gap:0.4rem; flex-wrap:wrap; margin-bottom:0.75rem; }
   .btn-sm { font-size:10px; padding:0.3rem 0.55rem; }
@@ -160,7 +174,8 @@
   .alert-green { background:var(--green-bg); border:1px solid var(--green); color:var(--green); }
   .tip-wrap { position:relative; display:inline-block; }
   .tip-icon { color:var(--text3); cursor:help; font-style:normal; font-size:11px; margin-left:0.3rem; }
-  .tip-icon:hover + .tip-box,.tip-icon:focus + .tip-box { display:block; }
+  .tip-icon:focus + .tip-box { display:block; }
+  @media (hover:hover) and (pointer:fine) { .tip-icon:hover + .tip-box { display:block; } }
   .tip-box { display:none; position:absolute; top:calc(100% + 6px); left:0; z-index:100; background:var(--bg4); border:1px solid var(--border2); border-radius:var(--radius); color:var(--text2); font-size:11px; line-height:1.5; max-width:280px; padding:0.5rem 0.65rem; white-space:normal; pointer-events:none; }
   .pre-out { background:var(--bg2); border:1px solid var(--border); border-radius:var(--radius-lg); color:var(--accent); font-family:var(--font-mono); font-size:11px; line-height:1.7; max-height:380px; overflow:auto; padding:1rem; white-space:pre; margin-bottom:0.6rem; }
   .lib-results { background:var(--bg2); border:1px solid var(--border); border-radius:var(--radius-lg); max-height:420px; overflow:auto; margin-bottom:0.6rem; }
@@ -174,7 +189,7 @@
   .lib-count { color:var(--text3); font-size:10px; letter-spacing:0.06em; text-transform:uppercase; margin-bottom:0.5rem; }
   .lib-row-actions { display:flex; gap:0.3rem; flex-shrink:0; }
   .row-btn { background:none; border:1px solid var(--border2); border-radius:var(--radius); color:var(--text2); cursor:pointer; font-family:inherit; font-size:11px; line-height:1.1; padding:0.2rem 0.4rem; }
-  .row-btn:hover { border-color:var(--accent); color:var(--accent); }
+  @media (hover:hover) and (pointer:fine) { .row-btn:hover { border-color:var(--accent); color:var(--accent); } }
   .lib-row.playing .lib-row-title,.lib-row.playing .lib-row-artist { color:var(--accent); }
   .lib-row-link { cursor:pointer; }
   .lib-row-check { flex-shrink:0; margin:0; }
@@ -183,11 +198,11 @@
      scroll container, so only the sticky-header math is new here. */
   .lib-table { width:100%; border-collapse:collapse; font-size:12px; }
   .lib-table th { position:sticky; top:0; background:var(--bg3); color:var(--text2); text-align:left; font-weight:500; font-size:10px; letter-spacing:0.04em; text-transform:uppercase; padding:0.5rem 0.6rem; border-bottom:1px solid var(--border); cursor:pointer; white-space:nowrap; user-select:none; }
-  .lib-table th:hover { color:var(--text); }
+  @media (hover:hover) and (pointer:fine) { .lib-table th:hover { color:var(--text); } }
   .lib-table th.sorted { color:var(--accent); }
   .lib-table td { padding:0.4rem 0.6rem; border-bottom:1px solid var(--border); color:var(--text); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; max-width:22rem; }
   .lib-table tr:last-child td { border-bottom:none; }
-  .lib-table tr:hover td { background:var(--bg3); }
+  @media (hover:hover) and (pointer:fine) { .lib-table tr:hover td { background:var(--bg3); } }
   .lib-table tr.playing td { color:var(--accent); }
   .lib-table td.lib-row-check-cell,.lib-table th.lib-col-check { width:1.6rem; padding-right:0; }
   .lib-table td.lib-row-actions-cell { white-space:nowrap; }
@@ -195,7 +210,7 @@
   .lib-columns-panel { display:none; position:absolute; z-index:80; top:calc(100% + 4px); right:0; min-width:220px; max-width:min(280px, calc(100vw - 2rem)); max-height:280px; overflow:auto; background:var(--bg2); border:1px solid var(--border2); border-radius:var(--radius); box-shadow:0 8px 28px rgba(0,0,0,0.4); padding:0.4rem; }
   .lib-columns-panel.open { display:block; }
   .lib-columns-panel label { display:flex; align-items:center; gap:0.4rem; font-size:12px; color:var(--text2); padding:0.2rem 0.3rem; cursor:pointer; white-space:nowrap; }
-  .lib-columns-panel label:hover { color:var(--text); }
+  @media (hover:hover) and (pointer:fine) { .lib-columns-panel label:hover { color:var(--text); } }
   .lib-columns-panel input { margin:0; }
   /* Filter rows (#64) — field · operator · value, one row per condition. */
   .filter-row { display:flex; gap:0.4rem; align-items:center; margin-bottom:0.4rem; }
@@ -212,14 +227,14 @@
   .action-bar { align-items:center; background:var(--bg2); border:1px solid var(--border); border-radius:var(--radius-lg); display:flex; flex-wrap:wrap; gap:0.4rem; margin-bottom:0.6rem; padding:0.6rem 0.7rem; }
   .action-scope { color:var(--text2); flex-basis:100%; font-size:11px; letter-spacing:0.04em; }
   .action-scope b { color:var(--accent); font-weight:500; }
-  .lib-row-link:hover .lib-row-title { color:var(--accent); }
+  @media (hover:hover) and (pointer:fine) { .lib-row-link:hover .lib-row-title { color:var(--accent); } }
   /* Context menu (#71) — one floating element, reused by every row type.
      The bar down the left of .ctx-target is the same promise the scope line
      makes: what the menu is about to touch is visible while it's open. */
   .ctx-menu { position:fixed; z-index:120; min-width:190px; padding:0.25rem 0; background:var(--bg2); border:1px solid var(--border2); border-radius:var(--radius); box-shadow:0 8px 28px rgba(0,0,0,0.4); }
   .ctx-menu button { display:block; width:100%; text-align:left; background:none; border:none; color:var(--text2); cursor:pointer; font-family:inherit; font-size:12px; padding:0.35rem 0.9rem; }
-  .ctx-menu button:hover { background:var(--bg3); color:var(--text); }
-  .ctx-menu button.danger:hover { color:var(--red); }
+  @media (hover:hover) and (pointer:fine) { .ctx-menu button:hover { background:var(--bg3); color:var(--text); } }
+  @media (hover:hover) and (pointer:fine) { .ctx-menu button.danger:hover { color:var(--red); } }
   .ctx-menu hr { border:none; border-top:1px solid var(--border); margin:0.25rem 0; }
   .lib-row.ctx-target { box-shadow:inset 2px 0 0 var(--accent); }
   /* Player: a sibling of .content, so playback survives a tab switch. The
@@ -237,7 +252,7 @@
      flow — opening it must not shrink .content's visible height. */
   .player-queue { position:fixed; right:1.25rem; width:320px; max-width:calc(100vw - 2.5rem); max-height:55vh; overflow:auto; background:var(--bg2); border:1px solid var(--border2); border-radius:var(--radius-lg); box-shadow:0 8px 28px rgba(0,0,0,0.4); z-index:60; }
   .player-queue .lib-row { cursor:pointer; }
-  .player-queue .lib-row:hover { background:var(--bg3); }
+  @media (hover:hover) and (pointer:fine) { .player-queue .lib-row:hover { background:var(--bg3); } }
   @media (prefers-color-scheme:light) {
     .player audio { color-scheme:light; }
     .player-queue,.ctx-menu { box-shadow:0 8px 28px rgba(0,0,0,0.18); }
@@ -249,7 +264,12 @@
      show a real percentage (mbsync/bpsync don't report counts at all), so
      this signals "still alive" rather than "how far along." */
   @keyframes job-pulse { 0%,100% { opacity:1; } 50% { opacity:0.45; } }
-  .job-pulse { animation:job-pulse 1.6s ease-in-out infinite; }
+  /* #114: static dimmed opacity says "in progress" without looping; the
+     animation is layered on top only when motion is welcome. */
+  .job-pulse { opacity:0.7; }
+  @media (prefers-reduced-motion: no-preference) {
+    .job-pulse { animation:job-pulse 1.6s ease-in-out infinite; opacity:1; }
+  }
   details.section summary.section-title { cursor:pointer; user-select:none; }
   details.section summary.section-title::-webkit-details-marker { color:var(--text3); }
   .kbd { background:var(--bg3); border:1px solid var(--border2); border-radius:3px; color:var(--text3); font-size:9px; padding:0.05rem 0.3rem; margin-right:0.35rem; }
@@ -277,7 +297,7 @@
   .import-log-wrap summary { color:var(--text3); cursor:pointer; font-size:10px; letter-spacing:0.06em; text-transform:uppercase; margin-bottom:0.4rem; }
   .auth-card { background:var(--bg2); border:1px solid var(--border); border-radius:var(--radius-lg); margin-bottom:0.75rem; overflow:hidden; }
   .auth-card-hd { display:flex; align-items:center; justify-content:space-between; padding:0.75rem 1rem; cursor:pointer; user-select:none; border-bottom:1px solid transparent; transition:background 0.1s; }
-  .auth-card-hd:hover { background:var(--bg3); }
+  @media (hover:hover) and (pointer:fine) { .auth-card-hd:hover { background:var(--bg3); } }
   .auth-card.open .auth-card-hd { border-bottom-color:var(--border); }
   .auth-card-title { font-size:12px; font-weight:700; letter-spacing:0.08em; text-transform:uppercase; }
   .auth-card-chevron { color:var(--text3); transition:transform 0.2s; }


### PR DESCRIPTION
## Summary
- 0 `:active` rules across 117 buttons → `transform:scale(0.97)` on the 5 base pressable classes (`.btn-primary` inherits `.btn`'s, since it's always paired with it in the markup).
- No easing token existed → added `--ease-out`, used by the press-feedback transitions. Durations unchanged.
- 18 `:hover` rules ungated despite the app shipping `apple-mobile-web-app-capable` (a Safari Web App target — hover sticks after tap without gating) → wrapped in `@media (hover:hover) and (pointer:fine)`. The one rule combining hover+focus (tooltip reveal) was split so only the hover half is gated; the focus half is real keyboard behavior and stays ungated.
- Two infinite animations (`job-pulse`, `dropPulse`) had no `prefers-reduced-motion` guard → both now animate only under `no-preference`; a static dimmed opacity keeps the "in progress"/"drop here" cue for the reduced-motion case instead of losing it.

Findings behind these: `design-pass-2026-08.md` (Phase 3), posted in full to #89.

## Test plan
- [x] All 12 test suites pass, no test changes needed
- [x] Verified in-browser: 5 `:active` rules present, 18 hover-media-gated rules (matches original ungated count), 2 reduced-motion-gated rules, `--ease-out` resolves correctly, no console errors

Closes #111, Closes #112, Closes #113, Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)