### PR TITLE
Raise --text3 to clear WCAG AA in both themes

### DIFF
--- a/beetsgui.html
+++ b/beetsgui.html
@@ -22,7 +22,14 @@
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   :root {
     --bg:#0f0f0f; --bg2:#1a1a1a; --bg3:#252525; --bg4:#2e2e2e;
-    --text:#e8e6e1; --text2:#a09e99; --text3:#6a6866;
+    --text:#e8e6e1; --text2:#a09e99;
+    /* #108: was #6a6866, 3.45:1 against --bg — fails AA (4.5:1) for the
+       ~23 uses of this token, most of which are real informational or
+       actionable text (tab labels, row metadata, similarity scores, a
+       delete-warning sentence), not decorative. Raised to clear AA
+       against both --bg and --bg3 (badges/kbd/candidate-index sit on
+       --bg3, not --bg). Same reasoning applies to the light values below. */
+    --text3:#918f8c;
     --border:#2e2e2e; --border2:#3a3a3a;
     --accent:#c8a96e; --accent2:#8b6f3e;
     --red:#c05c5c; --red-bg:#2a1515;
@@ -35,7 +42,7 @@
   @media (prefers-color-scheme:light) {
     :root {
       --bg:#f5f4f0; --bg2:#eceae4; --bg3:#e2e0d8; --bg4:#d8d6ce;
-      --text:#1a1918; --text2:#5a5856; --text3:#8a8886;
+      --text:#1a1918; --text2:#5a5856; --text3:#5f5d5a;
       --border:#d0cec6; --border2:#c4c2ba;
       --red-bg:#fce8e8; --yellow-bg:#fdf5e0; --green-bg:#e8f4ec;
     }
@@ -46,13 +53,13 @@
      "System" leaves data-theme unset and falls through to the @media rule. */
   html[data-theme="light"] {
     --bg:#f5f4f0; --bg2:#eceae4; --bg3:#e2e0d8; --bg4:#d8d6ce;
-    --text:#1a1918; --text2:#5a5856; --text3:#8a8886;
+    --text:#1a1918; --text2:#5a5856; --text3:#5f5d5a;
     --border:#d0cec6; --border2:#c4c2ba;
     --red-bg:#fce8e8; --yellow-bg:#fdf5e0; --green-bg:#e8f4ec;
   }
   html[data-theme="dark"] {
     --bg:#0f0f0f; --bg2:#1a1a1a; --bg3:#252525; --bg4:#2e2e2e;
-    --text:#e8e6e1; --text2:#a09e99; --text3:#6a6866;
+    --text:#e8e6e1; --text2:#a09e99; --text3:#918f8c;
     --border:#2e2e2e; --border2:#3a3a3a;
     --red-bg:#2a1515; --yellow-bg:#252010; --green-bg:#152a1e;
   }


### PR DESCRIPTION
## Summary
`--text3` measured 3.45:1 (dark) / 3.21:1 (light) against `--bg` — fails AA (4.5:1) — for a token used in ~23 places. Considered splitting into a decorative-vs-functional token pair, per the issue's own suggestion, but walking the actual consumer list found the large majority genuinely informational or actionable (tab labels, row metadata, import-candidate similarity scores, empty states, a delete-warning sentence), not decorative. A single raised value covers it without introducing a new token.

Also checked against `--bg3`, not just `--bg` — several consumers (`.badge`, `.kbd`, `.candidate-index`) sit on `--bg3`, and a value that only cleared AA against `--bg` still failed there. Final values clear both:
- dark: `#6a6866` → `#918f8c` (5.94:1 vs `--bg`, 4.75:1 vs `--bg3`)
- light: `#8a8886` → `#5f5d5a` (5.96:1 vs `--bg`, 4.96:1 vs `--bg3`)

Both stay distinct from `--text2`, though the gap is narrower in light mode — noted in the commit as an accepted constraint (typographic treatment still differentiates the tiers where raw color values are close) rather than something chased further.

Findings behind this: `design-pass-2026-08.md`, posted in full to #89.

## Test plan
- [x] All 12 test suites pass, no test changes needed
- [x] Verified in-browser: `--text3` resolves to the new values in both themes, contrast computed directly via `getComputedStyle` against both `--bg` and `--bg3`, visually checked at 1280px in light mode

Closes #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)