### PR TITLE
Sentence-case radio/checkbox option text

### DIFF
--- a/beetsgui.html
+++ b/beetsgui.html
@@ -102,7 +102,10 @@
   .field-row { display:flex; gap:0.5rem; align-items:flex-end; }
   .field-row .field { flex:1; margin-bottom:0; }
   .check-group { display:flex; flex-direction:column; gap:0.3rem; }
-  .check-item,.radio-item { display:flex; align-items:center; gap:0.5rem; font-size:12px; color:var(--text); cursor:pointer; }
+  /* #117: caps is right for short section titles/field labels, wrong for
+     full sentences of option text — was inheriting label{}'s uppercase
+     unintentionally, not by choice. */
+  .check-item,.radio-item { display:flex; align-items:center; gap:0.5rem; font-size:12px; color:var(--text); cursor:pointer; text-transform:none; }
   input[type="checkbox"],input[type="radio"] { width:auto; accent-color:var(--accent); cursor:pointer; }
   .check-row { display:flex; flex-wrap:wrap; gap:0.4rem 1rem; }
   .section { margin-bottom:1.25rem; }


### PR DESCRIPTION
## Summary
`.check-item`/`.radio-item` never overrode the global `label { text-transform:uppercase; }` rule, so full sentences of option text (e.g. "Auto-accept confident matches, skip the rest (recommended for large imports)") were shouted in caps — inherited, not a deliberate choice. Section titles and plain field labels are untouched.

One rule, no markup changes: `.check-item,.radio-item { text-transform:none; }`.

## Test plan
- [x] All 12 test suites pass, no test changes needed
- [x] Verified in-browser: option text (Copy/Move/Keep, import mode radios, scan-filter checkboxes) now sentence case; section titles and field labels (Skip paths containing, File handling, Import mode) still caps

Closes #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)